### PR TITLE
Feature #4: Agent Escalation Protocol

### DIFF
--- a/.claude/agents/architect.md
+++ b/.claude/agents/architect.md
@@ -51,6 +51,24 @@ Be specific:
 
 Not: "Consider the implications." Not: "This might be a concern."
 
+## Escalation Protocol
+
+When you encounter any of these, **STOP and return to Cal** instead of making assumptions:
+
+- **Missing business context** — Technical options are clear but the right choice depends on business priorities you don't have
+- **Breaking change required** — The right architecture requires changes that affect other teams or systems
+- **Irreversible decision** — Choice locks in a path that's expensive to undo
+- **Conflicting requirements** — Spec asks for things that are architecturally incompatible
+
+Format your escalation as:
+```
+ESCALATION: [category]
+QUESTION: [specific question]
+OPTIONS: [what you've considered with tradeoffs]
+RECOMMENDATION: [your best guess and why]
+BLOCKED: [yes/no — can you continue analyzing other areas while waiting?]
+```
+
 ## Recommendations
 
 For each concern, provide:

--- a/.claude/agents/coder.md
+++ b/.claude/agents/coder.md
@@ -106,6 +106,27 @@ class Campaign {
 6. Run tests after changes
 7. Report back: completed, blocked, or needs-review
 
+## Escalation Protocol
+
+When you encounter any of these, **STOP and return to Cal** with a structured question instead of guessing:
+
+- **Ambiguous requirement** — Multiple valid interpretations, no clear winner
+- **Risky refactor** — Change touches >3 files or modifies public interfaces
+- **Missing context** — Need info not available in codebase or spec
+- **Architecture decision** — Choice between patterns with non-obvious tradeoffs
+- **Behavioral fence** — Action could be destructive or hard to reverse
+
+Format your escalation as:
+```
+ESCALATION: [category]
+QUESTION: [specific question]
+OPTIONS: [what you've considered]
+RECOMMENDATION: [your best guess and why]
+BLOCKED: [yes/no — can you continue on other work while waiting?]
+```
+
+Do NOT guess and push through. Escalating is always better than rework.
+
 ## Rules
 
 - Follow project conventions in CLAUDE.md

--- a/.claude/agents/reviewer.md
+++ b/.claude/agents/reviewer.md
@@ -56,6 +56,24 @@ These are immediate FAIL conditions. Do not pass code that contains:
 6. UI follows design system (invoke `design` skill if reviewing UI code)
 7. No OWASP top 10 vulnerabilities
 
+## Escalation Protocol
+
+When you encounter any of these, **STOP and return to Cal** instead of making a judgment call:
+
+- **Ambiguous intent** — Code works but you can't tell if the behavior is intentional or a bug
+- **Architecture concern** — Issue goes beyond this code into system design
+- **Conflicting standards** — Project conventions contradict each other
+- **Risk assessment unclear** — Can't determine severity without domain context
+
+Format your escalation as:
+```
+ESCALATION: [category]
+QUESTION: [specific question]
+OPTIONS: [what you've considered]
+RECOMMENDATION: [your best guess and why]
+BLOCKED: [yes/no — can you continue reviewing other files while waiting?]
+```
+
 ## Output Format
 
 Report one of:

--- a/.claude/rules/coordinator.md
+++ b/.claude/rules/coordinator.md
@@ -13,10 +13,11 @@ When the user requests implementation ("build", "implement", "fix", "add", "writ
 5. Include OOD context in dispatch: remind agent to read `cal/OOD.md`, name the relevant domain objects, flag any translation boundaries
 6. Dispatch via Task tool with the agent's system prompt and context
 7. **OOD Spot-Check** — When agent returns, verify before reporting success: no utils/helpers/services created, computed properties for derived state, logic lives on domain objects
-8. Report outcome to user
-9. Update `cal/NOW.md` if task completed
-10. **Advance GitHub board** — move the Feature issue to the next column via `scripts/gh-board.sh move-card`. If Feature clears Cleanup, close it and check if Epic should advance.
-11. If learning emerged, append to `cal/cal.md`
+8. **Escalation Check** — If agent response contains `ESCALATION:`, surface the question to the user. Do NOT report the task as complete. After user answers, re-dispatch the agent with the answer.
+9. Report outcome to user
+10. Update `cal/NOW.md` if task completed
+11. **Advance GitHub board** — move the Feature issue to the next column via `scripts/gh-board.sh move-card`. If Feature clears Cleanup, close it and check if Epic should advance.
+12. If learning emerged, append to `cal/cal.md`
 
 Cal can be overridden for quick inline fixes if the user explicitly asks.
 


### PR DESCRIPTION
## Summary
- Added escalation protocol to all three agents (coder, reviewer, architect)
- Each agent has role-specific escalation triggers (e.g., coder escalates risky refactors, architect escalates irreversible decisions)
- Coordinator rule updated to recognize `ESCALATION:` format and surface questions to user
- Agents stop and ask instead of guessing through ambiguity

## Changes
- `.claude/agents/coder.md` — Escalation section with 5 trigger categories
- `.claude/agents/reviewer.md` — Escalation section with 4 trigger categories  
- `.claude/agents/architect.md` — Escalation section with 4 trigger categories
- `.claude/rules/coordinator.md` — Step 8 added: escalation check before reporting success

Closes #4

## Test plan
- [ ] Dispatch Coder with an ambiguous task — verify it escalates instead of guessing
- [ ] Dispatch Reviewer on code with conflicting conventions — verify escalation
- [ ] Verify Cal surfaces escalation questions to user, not swallows them

🤖 Generated with [Claude Code](https://claude.com/claude-code)