### PR TITLE
Feature #7: Dream-friendly journal structure

### DIFF
--- a/cal/cal.md
+++ b/cal/cal.md
@@ -1,29 +1,44 @@
-# Cal Journal
+# Cal Brain
 
-Project: [Project name]
+Cal's persistent project knowledge. Organized by topic, not chronologically.
+Auto Dream consolidates entries between sessions — keep entries atomic and topical.
+
+---
+
+## Principles Learned
+
+*Patterns promoted from repeated experience. These shape how Cal approaches new work.*
+
+- Lean into Claude Code native features (Auto Dream, hooks, memory) rather than building Cal-specific layers. Custom layers compete with native behavior and drift as Claude Code evolves.
 
 ---
 
 ## Deltas
 
-*Wrong assumptions surfaced. BELIEVED/ACTUAL/DELTA format.*
+*Wrong assumptions corrected. BELIEVED / ACTUAL / DELTA format. Auto Dream prunes resolved deltas.*
 
----
+- **gh-board.sh owner type (2026-04-16):** BELIEVED find_project could use user() for any repo owner. ACTUAL: Pixley-Growth is an org, needs organization(). DELTA: GitHub APIs often have user/org divergence — always check owner type.
 
-## AHAs
+- **gh-board.sh project scope (2026-04-16):** BELIEVED querying org-wide projects was safe. ACTUAL: returned boards from other projects (SimCinema). DELTA: always scope project queries to the repository, not the owner.
 
-*Discoveries worth encoding.*
-
----
-
-## Memories
-
-*User patterns, preferences, context that persists.*
+- **Branch workflow (2026-04-16):** BELIEVED feature PRs merge directly to main. ACTUAL: user wants release branches (cal-5.0) as integration points. DELTA: multi-feature releases use a release branch before main.
 
 ---
 
 ## Decisions
 
-*Choices made with rationale. CHOICE/RATIONALE/REVISIT-IF format.*
+*Architectural choices with rationale. CHOICE / RATIONALE / REVISIT-IF format.*
+
+- **PR workflow (2026-04-16):** CHOICE: All merges go through PRs. RATIONALE: Enables Codex automated review at no human cost — caught real bugs on first PR. REVISIT-IF: Codex review stops adding value.
+
+- **Release branches (2026-04-16):** CHOICE: Feature branches merge to release branch (cal-5.0), release branch merges to main. RATIONALE: Accumulate features before shipping, each PR gets Codex review. REVISIT-IF: single-feature releases become the norm.
+
+- **Auto-Journal approach (2026-04-16):** CHOICE: Lean into Claude Code Auto Dream for memory consolidation instead of building Cal-specific journaling. RATIONALE: Prompt-based journaling was inconsistent in past Cal versions. Hook-based is better but native Auto Dream already does the consolidation cycle. REVISIT-IF: Auto Dream proves insufficient for project-level context.
 
 ---
+
+## Active Context
+
+*Current state that helps orient new sessions. Auto Dream prunes when stale.*
+
+- Cal 5.0 in progress on `cal-5.0` branch. 7 features planned, Epic #3. Feature #4 (Escalation) in PR #12.

--- a/skills/save/SKILL.md
+++ b/skills/save/SKILL.md
@@ -18,13 +18,13 @@ Agent outputs are scaffolding. Once you've acted on them, the output doesn't mat
 
 ## Routing
 
-| Type | Destination | Lifespan |
-|------|-------------|----------|
-| `delta` | `cal/cal.md` | Permanent |
-| `aha` | `cal/cal.md` | Permanent |
-| `memory` | `cal/cal.md` | Permanent |
-| `decision` | `cal/cal.md` | Permanent |
-| `session` | `cal/memories/YYYY-MM-DD.md` | Prunable |
+| Type | Destination | Section in cal.md | Lifespan |
+|------|-------------|-------------------|----------|
+| `delta` | `cal/cal.md` | `## Deltas` | Permanent (Auto Dream prunes resolved) |
+| `aha` | `cal/cal.md` | `## Principles Learned` | Permanent |
+| `memory` | `cal/cal.md` | `## Active Context` | Prunable by Auto Dream when stale |
+| `decision` | `cal/cal.md` | `## Decisions` | Permanent |
+| `session` | `cal/memories/YYYY-MM-DD.md` | — | Prunable |
 
 ## Usage
 
@@ -87,3 +87,14 @@ On save, verify `cal/cal.md` exists. If not, create it with header.
 ## Size Guidance
 
 If `cal/cal.md` exceeds 300 lines, review and consolidate entries.
+
+## Dream-Friendly Format
+
+`cal/cal.md` is organized by **topic** (Principles, Deltas, Decisions, Active Context) not chronologically. This structure supports Auto Dream consolidation:
+
+- **Principles Learned** — Patterns promoted from experience. Dream may merge related principles.
+- **Deltas** — Wrong assumptions. Dream prunes when the correction is no longer relevant.
+- **Decisions** — Choices with rationale. Dream preserves unless explicitly revisited.
+- **Active Context** — Current state. Dream prunes when stale.
+
+When saving, append to the correct section. Keep entries atomic — one insight per bullet.

--- a/skills/save/SKILL.md
+++ b/skills/save/SKILL.md
@@ -41,15 +41,15 @@ Agent outputs are scaffolding. Once you've acted on them, the output doesn't mat
 
 ## Entry Schema
 
-All entries follow this format:
+Entries are **atomic bullets** appended to the correct section in `cal/cal.md`:
 
 ```markdown
-## [ISO-8601-DATE] [TYPE] — [TOPIC]
-
-[Content]
-
----
+- **[topic] ([YYYY-MM-DD]):** BELIEVED: X. ACTUAL: Y. DELTA: Z.
+- **[topic] ([YYYY-MM-DD]):** CHOICE: X. RATIONALE: Y. REVISIT-IF: Z.
+- **[topic] ([YYYY-MM-DD]):** [principle or context]
 ```
+
+One insight per bullet. Date in parentheses for Auto Dream pruning. No heading blocks.
 
 ## Session Save Template
 
@@ -82,7 +82,38 @@ Session saves go to `cal/memories/YYYY-MM-DD.md`:
 
 ## Location Check
 
-On save, verify `cal/cal.md` exists. If not, create it with header.
+On save, verify `cal/cal.md` exists. If not, create it with the full template including all four sections:
+
+```markdown
+# Cal Brain
+
+Cal's persistent project knowledge. Organized by topic, not chronologically.
+Auto Dream consolidates entries between sessions — keep entries atomic and topical.
+
+---
+
+## Principles Learned
+
+*Patterns promoted from repeated experience.*
+
+---
+
+## Deltas
+
+*Wrong assumptions corrected. BELIEVED / ACTUAL / DELTA format.*
+
+---
+
+## Decisions
+
+*Architectural choices with rationale. CHOICE / RATIONALE / REVISIT-IF format.*
+
+---
+
+## Active Context
+
+*Current state that helps orient new sessions. Auto Dream prunes when stale.*
+```
 
 ## Size Guidance
 


### PR DESCRIPTION
## Summary
- Restructured `cal/cal.md` from chronological to topical sections that Auto Dream can consolidate
- Four sections: Principles Learned, Deltas, Decisions, Active Context
- Seeded with learnings from this session (3 deltas, 2 decisions, 1 principle)
- Updated `/cal:save` skill to route entries to correct sections
- Leans into Claude Code native Auto Dream instead of building custom journaling

## Design rationale
Prompt-based auto-journaling was inconsistent in past Cal versions. Rather than building a Cal-specific consolidation layer, we structure the data so Auto Dream's native orient/harvest/consolidate/prune cycle works well with it.

Closes #7

## Test plan
- [ ] `/cal:save delta "..."` appends to Deltas section
- [ ] `/cal:save decision "..."` appends to Decisions section
- [ ] Verify Auto Dream can read and consolidate the new structure between sessions

🤖 Generated with [Claude Code](https://claude.com/claude-code)