### PR TITLE
Enrich swiftui27 skill with Apple's exported swiftui-whats-new-27 references

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "cal",
   "description": "Object-oriented coordinator — manages pipelines, dispatches agents, enforces OOD",
-  "version": "6.0.0",
+  "version": "6.1.0",
   "license": "MIT",
   "author": {
     "name": "Cal"

--- a/cal/cal.md
+++ b/cal/cal.md
@@ -37,6 +37,8 @@ Auto Dream consolidates entries between sessions — keep entries atomic and top
 
 - **Auto-Journal approach (2026-04-16):** CHOICE: Lean into Claude Code Auto Dream for memory consolidation instead of building Cal-specific journaling. RATIONALE: Prompt-based journaling was inconsistent in past Cal versions. Hook-based is better but native Auto Dream already does the consolidation cycle. REVISIT-IF: Auto Dream proves insufficient for project-level context.
 
+- **Vendor Apple's SwiftUI 27 skill (2026-06-10):** CHOICE: Vendor Apple's `swiftui-whats-new-27` references (Xcode 27 `xcrun agent skills export`) verbatim into `skills/swiftui27/references/`, keep Cal's SDK-verified extras (nav transitions, copy/cut/paste, glass background extension) inline. Apple's text is authoritative on conflict. RATIONALE: Apple-authored guidance beats Cal's reverse-engineered notes for the topics it covers (@State macro source breaks, @ContentBuilder, document model); enrich-not-replace preserves coverage Apple omits. REVISIT-IF: new Xcode 27 betas update the exported skill (re-export and re-vendor), or Anthropic/Apple ship a native distribution channel for these skills.
+
 ---
 
 ## Active Context

--- a/claude-code.json
+++ b/claude-code.json
@@ -1,6 +1,6 @@
 {
   "name": "cal",
-  "version": "6.0.0",
+  "version": "6.1.0",
   "skills": [
     {
       "name": "ood",

--- a/skills/swiftui27/SKILL.md
+++ b/skills/swiftui27/SKILL.md
@@ -111,5 +111,5 @@ Apple states iOS 27 SwiftUI is more responsive "without code changes" via faster
 
 ## Sourcing
 
-- `references/*.md`: Apple-authored, exported from Xcode 27 via `xcrun agent skills export` (skill `swiftui-whats-new-27`), vendored verbatim 2026-06-10. Re-export and re-vendor on new Xcode 27 betas.
+- `references/*.md`: Apple-authored, exported from Xcode 27 via `xcrun agent skills export` (skill `swiftui-whats-new-27`), vendored 2026-06-10. Two example-code fixes deviate from upstream (caught by Codex on PR #16): `document-based-apps.md` used a nonexistent `fileWrapper:` init label for `NotebookSnapshot.previousFileWrapper`, and `item-binding.md`'s pre-27 fallback never set its `isPresented` flag (now derived from the item binding). Re-export on new Xcode 27 betas and re-check whether upstream fixed these.
 - ✅ items: verified in `iPhoneOS27.0.sdk/System/Library/Frameworks/SwiftUI.framework/Modules/SwiftUI.swiftmodule/arm64e-apple-ios.swiftinterface` (Xcode-beta 27.0). Method and traps: see `os27` skill → "Sourcing." Re-grep a symbol's `@available` before relying on it; betas shift.

--- a/skills/swiftui27/SKILL.md
+++ b/skills/swiftui27/SKILL.md
@@ -1,26 +1,43 @@
 ---
 name: swiftui27
-description: "SwiftUI iOS/macOS 27 delta reference (WWDC 2026). SDK-verified new APIs layered on top of Axiom's iOS 26 SwiftUI skills — navigation transitions, drag/reorder overhaul, copy-cut-paste, toolbar overflow, tab bar minimize, document model, Liquid Glass background extension. Invoke for SwiftUI work targeting iOS 27."
+description: "SwiftUI iOS/macOS 27 delta reference (WWDC 2026) — Apple-authored references vendored from Xcode 27's exported agent skills, plus Cal SDK-verified extras. Use for any SwiftUI work targeting SDK 27. Use when a SwiftUI view using @State fails to compile with \"used before being initialized\", \"invalid redeclaration of synthesized property\", or \"extraneous argument label\" errors after an SDK update (@State became a macro in SDK 27 — the obvious fix of reordering init assignments is WRONG; consult references/state-macro.md first); when @ViewBuilder/@ContentBuilder code hits ambiguous overloads in overlay/background or type-check regressions; when adding drag-to-reorder to any container via reorderable()/reorderContainer; when working with AsyncImage caching or AsyncImage(request:); when adding swipe actions to rows outside List via swipeActionsContainer(); when controlling toolbar overflow (visibilityPriority, ToolbarOverflowMenu, toolbarMinimizeBehavior); when presenting alert/confirmationDialog from an optional item binding; when building or migrating document-based apps (ReadableDocument/WritableDocument, DocumentGroup); when using navigation transitions (.crossFade, AnyNavigationTransition), copy/cut/paste modifiers (copyable/cuttable/pasteDestination), tab bar minimize, or Liquid Glass background extension; or when resolving SDK 27.0 deprecation warnings."
 metadata:
-  author: Cal
-  version: 1.0.0
-  source: iPhoneOS27.0.sdk SwiftUI.swiftinterface (Xcode-beta 27.0)
+  author: Cal + Apple
+  version: 2.0.0
+  source: "Apple: Xcode 27 `xcrun agent skills export` (swiftui-whats-new-27, vendored 2026-06-10). Cal: iPhoneOS27.0.sdk SwiftUI.swiftinterface (Xcode-beta 27.0)."
 ---
 
 # SwiftUI — iOS / macOS 27 Delta (WWDC 2026)
 
-**Scope:** this is a **27-delta corrective**, not a SwiftUI tutorial. Axiom's `axiom-ios-ui` / `axiom-swiftui-26-ref` cover the iOS 26 baseline (Liquid Glass `glassEffect`, `@Animatable`, etc.) — use those for fundamentals. This skill is *only* what's new in 27, verified symbol-by-symbol against `iPhoneOS27.0.sdk`'s `SwiftUI.swiftinterface`.
+**Scope:** this is a **27-delta corrective**, not a SwiftUI tutorial. Axiom's `axiom-ios-ui` / `axiom-swiftui-26-ref` cover the iOS 26 baseline (Liquid Glass `glassEffect`, `@Animatable`, etc.) — use those for fundamentals. This skill is only what's new in 27.
 
-**Reality check on the press:** WWDC coverage hyped "hinge-state / foldable adaptive layout APIs." **There is no `hinge`/`fold`/`isFolded` symbol in SwiftUI or UIKit in the 27.0 SDK** (only CoreData and RoomPlan contain the substring "fold"). Treat foldable adaptivity as the existing size-class / `ViewThatFits` / `onGeometryChange` toolkit until a named API appears. Don't write code against an imagined `hingeState` environment value. 📰 = press-reported, ✅ = SDK-verified.
+**Authority:** everything under `references/` was written and published by Apple (exported from Xcode 27 via `xcrun agent skills export`). It is authoritative and unconditionally supersedes prior training *and* this file's inline notes on any conflict. Do not invent APIs or parameters not documented there. Before writing or modifying code that uses any new or changed SDK 27 SwiftUI API, read the relevant reference — several APIs have closely-named overloads with different closure signatures; picking from training memory fails to compile or misbehaves at runtime.
+
+**Reality check on the press:** WWDC coverage hyped "hinge-state / foldable adaptive layout APIs." **There is no `hinge`/`fold`/`isFolded` symbol in SwiftUI or UIKit in the 27.0 SDK.** Treat foldable adaptivity as the existing size-class / `ViewThatFits` / `onGeometryChange` toolkit until a named API appears. 📰 = press-reported, 🍎 = Apple-authored reference, ✅ = Cal SDK-verified.
 
 ---
 
-## 1. Navigation transitions ✅
+## Apple references (read before using these APIs) 🍎
+
+- `references/state-macro.md` — **`@State` migrated from property wrapper to macro.** Views that compiled before may fail with "variable used before being initialized" (init assigns `@State` before other stored properties), "invalid redeclaration of synthesized property" (composed property wrappers), or "extraneous argument label" (memberwise-init delegation in extensions). **For any compile error in a view using `@State` after an SDK update, read this first.** The fix is NOT reordering init assignments — that compiles but produces wrong runtime behavior (the initial-value expression wins; the init assignment is ignored).
+- `references/content-builder.md` — result builders unified under `@ContentBuilder`. Source-incompatible spots: ambiguous `ShapeStyle` overloads in `overlay`/`background`, ambiguous type references when a module shadows SwiftUI types, `TupleContent` vs `TupleView` mismatches, and a type-check performance regression in Swift Charts with deeply branching content.
+- `references/reorderable.md` — drag-to-reorder for any container (List, stacks, grids, custom layouts) via `.reorderable()` on `ForEach` + `.reorderContainer(for:)`: implementing the `ReorderDifference` apply, sections and multiple collections, drag-and-drop integration (`dragContainer`/`dropDestination`, `draggable(containerItemID:)`), and combining items by dropping one onto another. iOS/macOS/watchOS/visionOS 27; tvOS unavailable. Prefer this over manual `onMove` index juggling on 27.
+- `references/toolbar.md` — toolbar in constrained space: `visibilityPriority` (which items stay visible vs. overflow), `ToolbarOverflowMenu` (always-overflow items), `.topBarPinnedTrailing` (pinned item), `toolbarMinimizeBehavior` (minimize on scroll), `contentMarginsRemoved`, `ToolbarPlacement.statusBar`, and `ForEach`/`EmptyView` in toolbar builders. Availability varies per API — see the reference's table.
+- `references/swipe-actions.md` — swipe actions on rows in any scrollable container (ScrollView + LazyVStack/LazyVGrid/stack), not just `List`: mark the container `swipeActionsContainer()`, keep `swipeActions(edge:allowsFullSwipe:content:)` on each row; plus the new `onPresentationChanged` overload. tvOS unavailable.
+- `references/item-binding.md` — `confirmationDialog` and `alert` overloads taking `item: Binding<T?>` (the `sheet(item:)` shape): presents while non-nil, passes the unwrapped value to `actions`/`message`.
+- `references/async-image.md` — `AsyncImage` now applies standard HTTP caching by default; `AsyncImage(request:)` takes a `URLRequest` for per-request cache policy; `asyncImageURLSession(_:)` supplies a custom session.
+- `references/document-based-apps.md` — new `ReadableDocument`/`WritableDocument` document model (iOS/macOS/visionOS 27): read-only viewers (`DocumentGroup(viewer:makeReadableDocument:)`), direct file-URL access, background read/write via `DocumentReader`/`DocumentWriter`, `FileWrapperDocument{Reader,Writer}`, incremental package writes, `Subprogress`, undo. **When the deployment target is 27+, do not recommend `FileDocument`/`ReferenceFileDocument` for new code.**
+- `references/deprecations.md` — APIs hard-deprecated in SDK 27.0 (e.g. `statusBarHidden` on visionOS: no effect, remove the call).
+
+---
+
+## Cal SDK-verified extras (not covered by Apple's references) ✅
+
+### 1. Navigation transitions
 
 iOS 26 had `.zoom`. 27 adds type-erasure and a cross-fade, so you can store/compose transitions:
 
 ```swift
-// New: AnyNavigationTransition wraps any transition; .crossFade is new.
 .navigationTransition(.crossFade)                       // CrossFadeNavigationTransition
 .navigationTransition(.zoom(sourceID: item.id, in: ns)) // still here from 26
 
@@ -31,38 +48,9 @@ let t: AnyNavigationTransition = useZoom
 detailView.navigationTransition(t)
 ```
 
-`matchedTransitionSource(id:in:)` gained overloads for **toolbar content** (`ToolbarContent` / `CustomizableToolbarContent`) — you can now originate a zoom from a toolbar item. Note the SDK constraints: matched-transition source only supports `RoundedRectangle` clip shapes and `Color` backgrounds (both are `@available(*, unavailable)` otherwise — the compiler will tell you).
+`matchedTransitionSource(id:in:)` gained overloads for **toolbar content** — you can originate a zoom from a toolbar item. SDK constraints: matched-transition source only supports `RoundedRectangle` clip shapes and `Color` backgrounds (others are `@available(*, unavailable)`).
 
----
-
-## 2. Drag & reorder overhaul ✅
-
-The biggest single area of new surface in 27. A declarative reordering system replaces hand-rolled `onMove` for many cases.
-
-```swift
-// Mark a ForEach's dynamic content reorderable:
-ForEach(items) { item in RowView(item) }
-    .reorderable()                              // simplest form
-    .reorderable(collectionID: listID)          // when multiple collections interleave
-
-// Own the reorder semantics with a typed difference:
-List { ForEach(items) { RowView($0) } }
-    .reorderContainer(for: Item.self, in: ListID.self) { difference in
-        // difference: ReorderDifference<Item.ID, ListID>
-        model.apply(difference)
-    }
-```
-
-Drag/drop also gained:
-- `draggable(containerItemID:containerNamespace:)` — drag a whole container by id.
-- `onDragSessionUpdated { (session: DragSession) in … }` — observe an in-flight drag.
-- `reorderDestination(for:in:)` / `reorderContainer(for:itemID:in:isEnabled:move:)` overloads for KeyPath-identified items and single-collection cases (`ReorderableSingleCollectionIdentifier`).
-
-Prefer `reorderable()` / `reorderContainer` over manual `onMove` index juggling on iOS 27.
-
----
-
-## 3. First-class copy / cut / paste ✅
+### 2. First-class copy / cut / paste
 
 `Transferable`-based clipboard verbs as view modifiers (no responder-chain plumbing):
 
@@ -76,24 +64,11 @@ view
 // Command-driven variants: .onCopyCommand / .onCutCommand (NSItemProvider-based)
 ```
 
----
+### 3. Drag session observation
 
-## 4. Toolbar: overflow + visibility priority ✅
+Beyond Apple's reorder/drop coverage: `onDragSessionUpdated { (session: DragSession) in … }` observes an in-flight drag.
 
-```swift
-.toolbar {
-    ToolbarItem { SaveButton() }
-        .visibilityPriority(.high)        // kept when space is tight
-    ToolbarItem { InfoButton() }
-        .visibilityPriority(.low)         // first to collapse into overflow
-}
-```
-
-`ToolbarItemVisibilityPriority` is `Comparable` with `.automatic` / `.low` / `.high`, plus `init(lowerThan:)` / `init(higherThan:)` for custom ordering. Items that don't fit collapse into a new `ToolbarOverflowMenu` (also constructible directly via `toolbarOverflowMenu { … }`). This is how the Liquid Glass toolbar degrades gracefully on narrow widths.
-
----
-
-## 5. Tab bar minimize + Tabs picker ✅
+### 4. Tab bar minimize + Tabs picker
 
 ```swift
 TabView { … }
@@ -104,11 +79,9 @@ Picker("View", selection: $mode) { … }
     .pickerStyle(.tabs)                      // TabsPickerStyle
 ```
 
-`tabBarMinimizeBehavior` makes the floating (Liquid Glass) tab bar shrink to reclaim space while scrolling — pair with content that benefits from vertical room.
+`tabBarMinimizeBehavior` makes the floating (Liquid Glass) tab bar shrink while scrolling. (Toolbar/nav-bar minimize is `toolbarMinimizeBehavior` — see `references/toolbar.md`.)
 
----
-
-## 6. Liquid Glass: background extension ✅
+### 5. Liquid Glass: background extension
 
 The 27 glass addition (the `glassEffect` / `GlassEffectContainer` core shipped in 26 — see `cal:design`):
 
@@ -118,28 +91,25 @@ imageHeader
     .backgroundExtensionEffect(isEnabled: scrolledUnderNav)
 ```
 
-Use it for hero imagery and full-bleed backdrops that should appear *under* translucent chrome rather than being clipped to the safe area. The broader 27 glass guidance (refinements Apple says to adopt, the user transparency setting) lives in `cal:design`.
+Use for hero imagery and full-bleed backdrops that should appear *under* translucent chrome rather than clipped to the safe area. Broader 27 glass guidance lives in `cal:design`.
 
----
+### 6. Background scenes
 
-## 7. Document model + background scenes ✅
+`BackgroundTask.processingTask(_:)` joins `BackgroundTask.appRefresh(_:)` as a `backgroundTask(_:action:)` scene-modifier identifier — long background work modeled at the scene level (mirrors App Intents' `LongRunningIntent`, see `os27`).
 
-- New document plumbing: `WritableDocument`, `DocumentReader` / `DocumentWriter`, `FileWrapperDocumentReader/Writer`, `DocumentCreationContext`, `DocumentReadConfiguration` / `DocumentWriteConfiguration`, `NewDocumentButtonDataSource`, and a `fileExporter(isPresented:document:contentType:defaultFilename:onCompletion:onCancellation:)` overload. Relevant if you ship a `DocumentGroup` app.
-- `BackgroundTask.processingTask(_:)` joins `BackgroundTask.appRefresh(_:)` as a `backgroundTask(_:action:)` scene modifier identifier — long background work modeled at the scene level (mirrors App Intents' `LongRunningIntent`, see `os27`).
+### 7. Performance (📰, no API)
 
----
-
-## 8. Performance (📰, no API)
-
-Apple states iOS 27 SwiftUI is more responsive "without code changes" via faster state initialization and layout. There's no opt-in symbol — just build against the 27 SDK. No action required beyond testing.
+Apple states iOS 27 SwiftUI is more responsive "without code changes" via faster state initialization and layout. No opt-in symbol — just build against the 27 SDK and test.
 
 ---
 
 ## OOD / Cal notes
 
-- The reorder/drag system is state-difference driven (`ReorderDifference`) — apply the difference to the object that owns the collection (a parent entity's computed/owned array), not a free `onMove` closure scattered in the view. Keeps Pillar-1 logic on the model.
-- `Transferable` copy/cut/paste is the SwiftUI side of the same outbound-citizen idea in `cal/OOD.md`: expose a `Transferable` projection, not the raw model.
+- The reorder system is state-difference driven (`ReorderDifference`) — apply the difference to the object that owns the collection (a parent entity's computed/owned array), not a free `onMove` closure scattered in the view. Keeps Pillar-1 logic on the model.
+- `Transferable` copy/cut/paste is the SwiftUI side of the outbound-citizen idea in `cal/OOD.md`: expose a `Transferable` projection, not the raw model.
+- `ReadableDocument`/`WritableDocument` puts read/write logic ON the document type — the document model is the citizen; keep parsing out of views.
 
 ## Sourcing
 
-Every ✅ verified in `iPhoneOS27.0.sdk/System/Library/Frameworks/SwiftUI.framework/Modules/SwiftUI.swiftmodule/arm64e-apple-ios.swiftinterface` (Xcode-beta 27.0). Method and traps: see `os27` skill → "Sourcing." Re-grep a symbol's `@available` before relying on it; betas shift.
+- `references/*.md`: Apple-authored, exported from Xcode 27 via `xcrun agent skills export` (skill `swiftui-whats-new-27`), vendored verbatim 2026-06-10. Re-export and re-vendor on new Xcode 27 betas.
+- ✅ items: verified in `iPhoneOS27.0.sdk/System/Library/Frameworks/SwiftUI.framework/Modules/SwiftUI.swiftmodule/arm64e-apple-ios.swiftinterface` (Xcode-beta 27.0). Method and traps: see `os27` skill → "Sourcing." Re-grep a symbol's `@available` before relying on it; betas shift.

--- a/skills/swiftui27/references/async-image.md
+++ b/skills/swiftui27/references/async-image.md
@@ -1,0 +1,68 @@
+# AsyncImage
+**SDK Version:** 27.0 and later
+
+`AsyncImage` loads an image from a URL and displays it as it arrives. In the 2027 OS releases it applies standard HTTP caching by default: responses are cached according to the server's cache headers, so an image that already loaded can be served from the cache instead of downloaded again, with no code change and no API to enable. Two new entry points add control on top of that default: an initializer that takes a `URLRequest` in place of a `URL` (to set the cache policy or any other request property per image), and the `asyncImageURLSession(_:)` modifier (to supply a `URLSession` with its own `URLCache`).
+
+If the user's deployment target is below iOS 27 / macOS 27 / watchOS 27 / tvOS 27 / visionOS 27, the new `AsyncImage(request:)` initializers and the `asyncImageURLSession(_:)` modifier require availability gating. The default HTTP caching described in the next section is different: it is runtime behavior, not an API call, and applies whenever the app runs on a 2027 OS release regardless of the build SDK or deployment target. A generic "I want caching" ask on a deployment target below SDK 27 needs no code change; the existing `AsyncImage(url:)` already gets the cache on iOS 27+ devices.
+
+## Default HTTP caching
+
+HTTP caching applies to every `AsyncImage` automatically; no API call turns it on, and the cache honors the response's cache headers. Existing `AsyncImage(url:)` code keeps working and gains the cache without modification. The cache lives in the framework's image loader and is not gated on the app's build SDK, so an app gets it when running on the 2027 OS releases even if it was built against an earlier SDK; only the customization below requires the 27 SDK.
+
+```swift
+AsyncImage(url: imageURL)   // cached per the server's headers; no change required
+```
+
+**Availability:** iOS 27, macOS 27, watchOS 27, tvOS 27, visionOS 27.
+
+## Per-request control with URLRequest
+
+The new `init(request:)` initializers take a `URLRequest` instead of a `URL`, so you set the request's `cachePolicy` (or any other property) yourself. The remaining labels match the `URL` initializers: `scale:` (default `1`), and either a `content:`/`placeholder:` pair or a `transaction:` plus a single `content:` closure that receives an `AsyncImagePhase`. The bare `AsyncImage(request:)` with no closures renders the loaded image directly, like `AsyncImage(url:)`.
+
+```swift
+AsyncImage(request: URLRequest(url: imageURL, cachePolicy: .returnCacheDataElseLoad)) { image in
+    image.resizable().scaledToFit()
+} placeholder: {
+    ProgressView()
+}
+// URLRequest.CachePolicy: .returnCacheDataElseLoad, .returnCacheDataDontLoad,
+// .reloadIgnoringLocalCacheData, .reloadRevalidatingCacheData, .useProtocolCachePolicy
+```
+
+**Availability:** iOS 27, macOS 27, watchOS 27, tvOS 27, visionOS 27.
+
+## Custom URLSession
+
+`asyncImageURLSession(_:)` sets the `URLSession` that the `AsyncImage` views in its subtree use to load images. Configure that session's `URLCache` to set the memory and disk capacity the images are cached with.
+
+```swift
+struct GalleryView: View {
+    private static let imageSession: URLSession = {
+        let configuration = URLSessionConfiguration.default
+        configuration.urlCache = URLCache(memoryCapacity: 64 * 1024 * 1024,
+                                           diskCapacity: 256 * 1024 * 1024)
+        return URLSession(configuration: configuration)
+    }()
+
+    var body: some View {
+        ScrollView {
+            LazyVStack {
+                ForEach(photos) { photo in
+                    AsyncImage(request: URLRequest(url: photo.url, cachePolicy: .returnCacheDataElseLoad))
+                }
+            }
+        }
+        .asyncImageURLSession(Self.imageSession)
+    }
+}
+```
+
+**Availability:** iOS 27, macOS 27, watchOS 27, tvOS 27, visionOS 27.
+
+## Availability summary
+
+| API | iOS | macOS | watchOS | tvOS | visionOS |
+|---|---|---|---|---|---|
+| Default HTTP caching | 27 | 27 | 27 | 27 | 27 |
+| `AsyncImage(request:…)` initializers | 27 | 27 | 27 | 27 | 27 |
+| `asyncImageURLSession(_:)` | 27 | 27 | 27 | 27 | 27 |

--- a/skills/swiftui27/references/content-builder.md
+++ b/skills/swiftui27/references/content-builder.md
@@ -1,0 +1,404 @@
+# ContentBuilder Unification
+**SDK Version:** 27.0 and later
+
+Many of SwiftUI's result builders (most notably `@ViewBuilder`) have been unified under `@ContentBuilder`. This changes the type-checking model: result builders no longer constrain their block contents to conform to `View`. As a result, you may encounter source incompatibilities in existing code. Here are the issues and how to fix them:
+
+## Ambiguous ShapeStyle Modifiers in `overlay` or `background`
+**Issue:**
+Code that passes a `ShapeStyle` expression with modifiers like `.opacity()` or `.blendMode()` directly to the deprecated non-builder `overlay` or `background` may produce:
+
+```
+error: ambiguous use of 'opacity'
+error: ambiguous use of 'blendMode'
+```
+
+For example, this code will fail to compile:
+```swift
+import SwiftUI
+
+struct ContentView: View {
+    var body: some View {
+        Text("Hello")
+            .overlay(Color.blue.opacity(0.70).blendMode(.overlay))
+    }
+}
+```
+
+**Fix:**
+Use the trailing-closure variant of `overlay` or `background` instead of passing the expression as a direct argument.
+
+```swift
+import SwiftUI
+
+struct ContentView: View {
+    var body: some View {
+        Rectangle()
+            .overlay { Color.blue.opacity(0.3).blendMode(.overlay) }
+    }
+}
+```
+
+**Reason:**
+The `overlay` and `background` modifiers each have two overloads: one accepting a `View` (marked as disfavored) and one accepting a `ShapeStyle`. Separately, modifiers like `.opacity()` and `.blendMode()` on `ShapeStyle` are also overloaded to return either a `ShapeStyle` or a `View`. Previously, `@ViewBuilder`'s `View` constraint forced the compiler to pick the `View`-returning variant of `.opacity()`, which then resolved `overlay` unambiguously to the `ShapeStyle` overload.
+
+With `@ContentBuilder` removing the `View` constraint, the `ShapeStyle`-returning variant of `.opacity()` must now be disfavored to preserve the previous default behavior. However, this creates a new problem when combined with `overlay`: each possible resolution path has exactly one disfavored overload (either the `View`-accepting `overlay` or the `ShapeStyle`-returning `.opacity()`), making the overall expression ambiguous. Using the trailing-closure variant explicitly selects the builder-based overload of `overlay`, breaking the tie.
+
+## Ambiguous Type References When Another Module Shadows SwiftUI Types
+**Issue:**
+If your project imports a module that declares a type with the same name as a SwiftUI type (for example, its own `Color` type with a `.red` property), you may see:
+
+```
+error: ambiguous use of 'red'
+```
+
+This can occur with any duplicated static member (e.g., `.green`, `.blue`, `.clear`), not just `.red`, or a type with the same name as a SwiftUI type. For example, if a framework declared a type called `Text` with overloads that match those found in SwiftUI's `Text`, this would now be ambiguous. The common theme is that these were previously only disambiguated by the `View` constraint on `@ViewBuilder`'s `buildBlock`.
+
+For example, this code will fail to compile if `MyPackage` also declares a `Color` type with a `.clear` member:
+```swift
+// In MyPackage:
+public struct Color {
+    public static let clear = Color()
+}
+
+// In your app:
+import SwiftUI
+import MyPackage
+
+struct ContentView: View {
+    var body: some View {
+        Color.clear
+    }
+}
+```
+
+**Fix:**
+Fully qualify the type to disambiguate which module's type you intend to use, or rename the type / members in `MyPackage` to make them distinct from those in SwiftUI.
+
+```swift
+import SwiftUI
+import MyPackage
+
+struct ContentView: View {
+    var body: some View {
+        SwiftUI.Color.clear
+    }
+}
+```
+
+**Reason:**
+Previously, `@ViewBuilder`'s `View` constraint helped the compiler disambiguate between identically-named types across modules, because it could rule out the non-`View`-conforming candidate. With `@ContentBuilder` removing that constraint, the compiler sees both candidates as equally valid and reports an ambiguity.
+
+## `TupleContent` vs `TupleView` Type Mismatch
+**Issue:**
+Code that explicitly references `TupleView` as a nested generic type parameter may produce:
+
+```
+error: cannot convert value of type 'VStack<TupleContent<Text, Text>>' to expected argument type 'VStack<TupleView<(Text, Text)>>'
+```
+
+This appears when `TupleView` is nested inside another container's generic parameter:
+```
+error: cannot convert value of type 'Label<TupleContent<Text, Text?>, Image?>' to expected argument type 'Label<TupleView<(Text, Optional<Text>)>, Optional<Image>>'
+```
+
+For example, this code will fail to compile:
+```swift
+import SwiftUI
+
+struct CardView<Content: View>: View {
+    var content: Content
+    var body: some View { content }
+    init(@ContentBuilder content: () -> Content) {
+        self.content = content()
+    }
+}
+
+extension CardView where Content == VStack<TupleView<(Text, Text)>> {
+    init(title: String, subtitle: String) {
+        self = CardView {
+            VStack {
+                Text(title)
+                Text(subtitle)
+            }
+        }
+    }
+}
+```
+
+**Fix:**
+Avoid hard-coding `TupleContent` or `TupleView` in generic type parameters. If you must spell the concrete type, use `TupleContent` instead of `TupleView` to match the new builder return type. If your deployment target is lower than any Apple OS 27.0, you can explicitly construct a `TupleView` inside the builder instead. Prefer using `some View` or other opaque types where possible.
+
+```swift
+import SwiftUI
+
+struct CardView<Content: View>: View {
+    var content: Content
+    var body: some View { content }
+    init(@ContentBuilder content: () -> Content) {
+        self.content = content()
+    }
+}
+
+extension CardView where Content == VStack<TupleContent<Text, Text>> {
+    init(title: String, subtitle: String) {
+        self = CardView {
+            VStack {
+                Text(title)
+                Text(subtitle)
+            }
+        }
+    }
+}
+```
+
+or if your deployment target is lower than any Apple OS 27.0, you can do the equivalent with `TupleView`:
+
+```swift
+import SwiftUI
+
+struct CardView<Content: View>: View {
+    var content: Content
+    var body: some View { content }
+    init(@ContentBuilder content: () -> Content) {
+        self.content = content()
+    }
+}
+
+extension CardView where Content == VStack<TupleView<(Text, Text)>> {
+    init(title: String, subtitle: String) {
+        self = CardView {
+            VStack {
+                TupleView((
+                    Text(title),
+                    Text(subtitle)
+                ))
+            }
+        }
+    }
+}
+```
+
+**Reason:**
+The unified `@ContentBuilder` produces `TupleContent` rather than `TupleView` as the concrete return type for multi-expression builder blocks. When `TupleView` appears as a nested generic parameter (e.g., `VStack<TupleView<...>>`), the contextual type cannot propagate deep enough to guide the inner builder, causing a type mismatch. Updating the constraint to use `TupleContent`, or explicitly constructing `TupleView` inside the builder, resolves the issue.
+
+## Empty Builder Body with MapKit
+**Issue:**
+When both SwiftUI and MapKit are dependencies of the same file an empty result builder body (or a `#if` block with no `#else` branch) inside of a nested builder will produce:
+
+```
+error: return type of property 'body' requires that 'EmptyMapContent' conform to 'View'
+```
+
+Note that this can happen even in files where `MapKit` is not explicitly imported if the project does not have member import visibility turned on. For this reason, do not rule this issue out just because the file doesn't import `MapKit`.
+
+For example, this code will fail to compile:
+
+```swift
+import SwiftUI
+import MapKit
+
+struct ContentView: View {
+    var body: some View {
+        Group { }
+    }
+}
+```
+
+**Fix:**
+Explicitly use `EmptyContent` (or `EmptyView`) rather than leaving the block empty.
+
+```swift
+import SwiftUI
+import MapKit
+
+struct ContentView: View {
+    var body: some View {
+        Group {
+            EmptyContent()
+        }
+    }
+}
+```
+
+**Issue:**
+This also commonly occurs with conditional compilation blocks, as you can end up with an empty block in your else branch, for example the following code runs into the same issue when `MY_CONDITION` is `FALSE` as the block becomes empty:
+
+```swift
+import SwiftUI
+import MapKit
+
+struct ContentView: View {
+    var body: some View {
+        Group {
+            #if MY_CONDITION
+            MyView()
+            #endif
+        }
+    }
+}
+```
+
+**Fix:**
+Add an explicit else branch with an `EmptyContent` (or `EmptyView`).
+
+```swift
+import SwiftUI
+import MapKit
+
+struct ContentView: View {
+    var body: some View {
+        Group {
+            #if MY_CONDITION
+            MyView()
+            #else
+            EmptyContent()
+            #endif
+        }
+    }
+}
+```
+
+**Reason:**
+Without the `View` constraint on the builder, an empty builder body becomes ambiguous when MapKit is also imported, because MapKit defines its own result builder that can produce `EmptyMapContent`. Providing an explicit `EmptyContent()` (or `EmptyView()`) resolves the ambiguity by giving the compiler a concrete `View`-conforming expression.
+
+## Type-Check Timeout in Swift Charts with Deeply Branching Content (Back-Deployment Only)
+**Issue:**
+When your project's minimum deployment target is lower than any Apple OS 27.0, deeply branching `if`/`else if` or `switch` statements inside a `Chart` closure may produce:
+
+```
+error: the compiler is unable to type-check this expression in reasonable time
+```
+
+This only occurs when back-deploying — projects that target OS 27.0 or later are not affected. It typically manifests when the branching logic has many cases (roughly 10+).
+
+For example, this code will fail to compile:
+```swift
+import SwiftUI
+import Charts
+
+struct DataPoint {
+    var index: Int
+    var rate: Double
+    var signal: Double
+    var noise: Double
+    var errors: Double
+    var throughput: Double
+    var txRate: Double
+    var rxRate: Double
+    var txFrames: Double
+    var rxFrames: Double
+    var channel: Double
+    var bandwidth: Double
+    var defaultValue: Double
+}
+
+struct MetricChartView: View {
+    var selectedMetric: String
+    var dataPoints: [DataPoint]
+
+    var body: some View {
+        Chart(dataPoints, id: \.index) { dataPoint in
+            if selectedMetric == "Rate" {
+                LineMark(x: .value("X", dataPoint.index), y: .value("Y", dataPoint.rate))
+                    .foregroundStyle(.blue)
+            } else if selectedMetric == "Signal" {
+                LineMark(x: .value("X", dataPoint.index), y: .value("Y", dataPoint.signal))
+                    .foregroundStyle(.green)
+            } else if selectedMetric == "Noise" {
+                LineMark(x: .value("X", dataPoint.index), y: .value("Y", dataPoint.noise))
+                    .foregroundStyle(.red)
+            } else if selectedMetric == "Errors" {
+                LineMark(x: .value("X", dataPoint.index), y: .value("Y", dataPoint.errors))
+                    .foregroundStyle(.orange)
+            } else if selectedMetric == "Throughput" {
+                LineMark(x: .value("X", dataPoint.index), y: .value("Y", dataPoint.throughput))
+                    .foregroundStyle(.purple)
+            } else if selectedMetric == "TX Rate" {
+                LineMark(x: .value("X", dataPoint.index), y: .value("Y", dataPoint.txRate))
+                    .foregroundStyle(.cyan)
+            } else if selectedMetric == "RX Rate" {
+                LineMark(x: .value("X", dataPoint.index), y: .value("Y", dataPoint.rxRate))
+                    .foregroundStyle(.mint)
+            } else if selectedMetric == "TX Frames" {
+                LineMark(x: .value("X", dataPoint.index), y: .value("Y", dataPoint.txFrames))
+                    .foregroundStyle(.indigo)
+            } else if selectedMetric == "RX Frames" {
+                LineMark(x: .value("X", dataPoint.index), y: .value("Y", dataPoint.rxFrames))
+                    .foregroundStyle(.brown)
+            } else if selectedMetric == "Channel" {
+                LineMark(x: .value("X", dataPoint.index), y: .value("Y", dataPoint.channel))
+                    .foregroundStyle(.teal)
+            } else if selectedMetric == "Bandwidth" {
+                LineMark(x: .value("X", dataPoint.index), y: .value("Y", dataPoint.bandwidth))
+                    .foregroundStyle(.pink)
+            } else {
+                LineMark(x: .value("X", dataPoint.index), y: .value("Y", dataPoint.defaultValue))
+                    .foregroundStyle(.gray)
+            }
+        }
+    }
+}
+```
+
+**Fix:**
+Extract the branching logic into a separate function annotated with `@ChartContentBuilder`. This switches back to the existing model for typechecking back-deployed code.
+
+```swift
+import SwiftUI
+import Charts
+
+struct MetricChartView: View {
+    var selectedMetric: String
+    var dataPoints: [DataPoint]
+
+    var body: some View {
+        Chart(dataPoints, id: \.index) { dataPoint in
+            marks(for: dataPoint)
+        }
+    }
+
+    @ChartContentBuilder
+    private func marks(for dataPoint: DataPoint) -> some ChartContent {
+        if selectedMetric == "Rate" {
+            LineMark(x: .value("X", dataPoint.index), y: .value("Y", dataPoint.rate))
+                .foregroundStyle(.blue)
+        } else if selectedMetric == "Signal" {
+            LineMark(x: .value("X", dataPoint.index), y: .value("Y", dataPoint.signal))
+                .foregroundStyle(.green)
+        } else if selectedMetric == "Noise" {
+            LineMark(x: .value("X", dataPoint.index), y: .value("Y", dataPoint.noise))
+                .foregroundStyle(.red)
+        } else if selectedMetric == "Errors" {
+            LineMark(x: .value("X", dataPoint.index), y: .value("Y", dataPoint.errors))
+                .foregroundStyle(.orange)
+        } else if selectedMetric == "Throughput" {
+            LineMark(x: .value("X", dataPoint.index), y: .value("Y", dataPoint.throughput))
+                .foregroundStyle(.purple)
+        } else if selectedMetric == "TX Rate" {
+            LineMark(x: .value("X", dataPoint.index), y: .value("Y", dataPoint.txRate))
+                .foregroundStyle(.cyan)
+        } else if selectedMetric == "RX Rate" {
+            LineMark(x: .value("X", dataPoint.index), y: .value("Y", dataPoint.rxRate))
+                .foregroundStyle(.mint)
+        } else if selectedMetric == "TX Frames" {
+            LineMark(x: .value("X", dataPoint.index), y: .value("Y", dataPoint.txFrames))
+                .foregroundStyle(.indigo)
+        } else if selectedMetric == "RX Frames" {
+            LineMark(x: .value("X", dataPoint.index), y: .value("Y", dataPoint.rxFrames))
+                .foregroundStyle(.brown)
+        } else if selectedMetric == "Channel" {
+            LineMark(x: .value("X", dataPoint.index), y: .value("Y", dataPoint.channel))
+                .foregroundStyle(.teal)
+        } else if selectedMetric == "Bandwidth" {
+            LineMark(x: .value("X", dataPoint.index), y: .value("Y", dataPoint.bandwidth))
+                .foregroundStyle(.pink)
+        } else {
+            LineMark(x: .value("X", dataPoint.index), y: .value("Y", dataPoint.defaultValue))
+                .foregroundStyle(.gray)
+        }
+    }
+}
+```
+
+**Reason:**
+To support back-deployment of `@ContentBuilder` in Charts, a compatibility overload of `buildEither` is needed that emits a Charts-specific `BuilderConditional` type. This additional overload degrades the compiler's type-checking performance for branching expressions inside chart builders. When many branches are present, the exponential growth in candidate overloads causes the compiler to exceed its expression complexity limit. This only affects back-deployed configurations (minimum deployment target < OS 27.0) because the compatibility overload is not needed when targeting OS 27.0 or later. Extracting the branching into a dedicated `@ChartContentBuilder` function isolates the type-checking, keeping each expression within the compiler's complexity budget. While typechecking performance is degraded in this particular instance, this tradeoff improves typechecking performance even for projects with lower minimum deployment targets for chart content outside of this case, and for *all* SwiftUI content which imports Charts.

--- a/skills/swiftui27/references/deprecations.md
+++ b/skills/swiftui27/references/deprecations.md
@@ -1,0 +1,45 @@
+# Deprecations
+**SDK Version:** 27.0 and later
+
+APIs hard-deprecated in SDK 27.0. Soft-deprecated APIs are covered by the `swiftui-specialist` skill's `soft-deprecated-apis.md` reference.
+
+## `View.statusBarHidden(_:)` on visionOS → remove
+
+**Platforms:** visionOS
+
+**Issue:**
+On visionOS, `statusBarHidden(_:)` is hard-deprecated at version 27.0 and produces a compiler warning:
+
+```
+'statusBarHidden' was deprecated in visionOS 27.0: Has no effect on visionOS
+```
+
+**Before:**
+```swift
+struct ImmersiveView: View {
+    var body: some View {
+        ZStack {
+            Color.black
+            Text("Immersive Content")
+        }
+        .statusBarHidden(true)
+    }
+}
+```
+
+**Fix:**
+Remove the call entirely — it has no effect on visionOS:
+
+```swift
+struct ImmersiveView: View {
+    var body: some View {
+        ZStack {
+            Color.black
+            Text("Immersive Content")
+        }
+    }
+}
+```
+
+**Reason:**
+visionOS does not have a status bar in the iOS sense, so the modifier is a no-op. The deprecation surfaces this so cross-platform code can be cleaned up.

--- a/skills/swiftui27/references/document-based-apps.md
+++ b/skills/swiftui27/references/document-based-apps.md
@@ -1,0 +1,530 @@
+# Document-Based Apps: `ReadableDocument` / `WritableDocument`
+**SDK Version:** 27.0 and later
+**Platforms:** iOS 27, macOS 27, visionOS 27. **Unavailable** on watchOS and tvOS.
+
+If the user's deployment target is below iOS 27 / macOS 27 / visionOS 27, do not use these APIs unconditionally.
+
+SDK 27.0 introduces two new protocols for document-based apps: `ReadableDocument` (read-only) and `WritableDocument` (adds saving). They give the document model **direct access to the file URL**, run reading and writing in the background, support progress reporting, and support coordinated disk access at any time. For new code, always prefer them over `ReferenceFileDocument` and `FileDocument`.
+
+## Mental model
+
+- A **document** is a reference type (`@Observable final class`) that conforms to `ReadableDocument` (read-only), `WritableDocument` (write-only, rare), or both (read-write, this is the most common default case). `DocumentGroup`'s read-write initializer requires `ReadableDocument & WritableDocument`. Because it's a reference type, SwiftUI doesn't recreate the document on every change; `@Observable` tracks individual property changes, so a `TextEditor` bound to a document property doesn't destroy the model on every keystroke.
+- A **snapshot** is a value capturing the document's state. It connects the document to its reader and writer. It can be any type (including the document type itself, a `String`, or a custom struct). Reading and writing may use **different** snapshot types.
+- A **`DocumentReader`** converts a file into a snapshot in the background; a **`DocumentWriter`** converts a snapshot back to disk in the background. These are independent types, usually nested in the document.
+- SwiftUI coordinates file access and runs reading/writing off the main actor automatically.
+
+### Save / open flow
+
+When SwiftUI autosaves or the person presses Command-S:
+1. SwiftUI calls `snapshot(contentType:)` **on the main actor** to capture state.
+2. SwiftUI calls `writer(configuration:)` to get the `DocumentWriter`.
+3. SwiftUI calls the writer's `write(content:to:previous:progress:)` **in the background** with coordinated file access.
+
+Reading is the mirror: SwiftUI calls `reader(configuration:)`, then `read(from:progress:)` **in the background**, then delivers the snapshot via `apply(snapshot:previous:)` **on the main actor**.
+
+> **Important:** `snapshot(contentType:)` and `apply(snapshot:previous:)` run on the **main actor**. Keep them lightweight. Do all serialization / deserialization inside the writer's `write(…)` and the reader's `read(…)`.
+
+## Set up the app: `DocumentGroup`
+
+```swift
+@main
+struct NotesApp: App {
+    var body: some Scene {
+        DocumentGroup { document in
+            TextEditorView(document: document)
+        } makeDocument: { configuration, context in
+            TextDocument(configuration: configuration, context: context)
+        }
+    }
+}
+```
+
+`DocumentGroup` takes two closures:
+
+- **`editor`** (read-write, `ReadableDocument & WritableDocument`) or **`viewer`** (read-only, `ReadableDocument`): builds the UI for an open document.
+- **`makeDocument`** / **`makeReadableDocument`**: creates the document instance. It receives:
+  - `configuration: URLDocumentConfiguration`: file URL (`nil` for new documents), last modification date, and a file-coordinator factory.
+  - `context: DocumentCreationContext`: exposes `creationSource: DocumentCreationSource?`, the source associated with the `NewDocumentButton` that triggered creation (iOS/visionOS).
+
+`makeDocument` is `async` and may `throw`. Throw `CancellationError` to cancel, or `await` to present pre-creation UI (a template picker, import preview).
+
+### Read-only documents
+
+Conform only to `ReadableDocument` and use `viewer` / `makeReadableDocument`:
+
+```swift
+DocumentGroup { document in
+    PDFViewer(document: document)
+} makeReadableDocument: { configuration, context in
+    PDFDocument(configuration: configuration, context: context)
+}
+```
+
+Set `CFBundleTypeRole` to `Viewer` in Info.plist (`Editor` for read-write).
+
+## `FileWrapperDocumentReader` / `FileWrapperDocumentWriter` (recommended)
+
+These convenience types handle file reading and writing: you supply closures that convert between your snapshot and a `FileWrapper`. **This is the recommended path for both flat-file and package documents,** including incremental package writes. Reach for a custom `DocumentReader` / `DocumentWriter` only when you need streaming, direct URL access for another framework, or want to avoid `FileWrapper`'s per-file `Data` conversion in a very large package.
+
+### Flat-file document
+
+```swift
+import SwiftUI
+import UniformTypeIdentifiers
+
+@Observable
+final class TextDocument: ReadableDocument, WritableDocument {
+    static let readableContentTypes = [UTType.utf8PlainText]
+
+    var text: String
+    var configuration: URLDocumentConfiguration
+
+    init(configuration: URLDocumentConfiguration) {
+        self.text = ""
+        self.configuration = configuration
+    }
+
+    func reader(
+        configuration: sending DocumentReadConfiguration
+    ) -> sending FileWrapperDocumentReader<String> {
+        FileWrapperDocumentReader(configuration) { fileWrapper in
+            guard let data = fileWrapper.regularFileContents,
+                  let text = String(data: data, encoding: .utf8) else {
+                return ""
+            }
+            return text
+        }
+    }
+
+    @MainActor
+    func apply(snapshot: String, previous: String?) async throws {
+        self.text = snapshot
+    }
+
+    func writer(
+        configuration: sending DocumentWriteConfiguration
+    ) -> sending FileWrapperDocumentWriter<String> {
+        FileWrapperDocumentWriter(configuration) { snapshot in
+            FileWrapper(regularFileWithContents: Data(snapshot.utf8))
+        }
+    }
+
+    @MainActor
+    func snapshot(contentType: UTType) async throws -> String { text }
+}
+
+struct TextEditorView: View {
+    @Bindable var document: TextDocument
+    @Environment(\.undoManager) private var undoManager
+
+    var body: some View {
+        TextEditor(text: $document.text)
+            .padding()
+            .onChange(of: document.text) { old, new in
+                document.registerTextUndo(from: old, undoManager: undoManager)
+            }
+    }
+}
+
+@main
+struct MyTextApp: App {
+    var body: some Scene {
+        DocumentGroup { document in
+            TextEditorView(document: document)
+        } makeDocument: { configuration, context in
+            TextDocument(configuration: configuration)
+        }
+    }
+}
+```
+
+### Package documents (incremental read/write)
+
+A package is a directory the system shows as a single item. Packages let you read and write **incrementally**: load only what's needed, write only what changed.
+
+The `FileWrapperDocumentWriter` closure takes a **single argument**, the snapshot.  To write incrementally, **hold onto the `FileWrapper` from the last read or save** on the document and reuse its unchanged children. Carry an `isChanged` flag on each page so the writer can skip serialization entirely for pages whose bytes are still in sync with disk; the save touches only the pages the person actually edited.
+
+For incremental read, perform on-demand read via a `FileCoordinator`, provided by `URLDocumentConfiguration`.
+
+```swift
+struct NotebookSnapshot {
+    var metadata: NotebookMetadata
+    var pages: [UUID: NotebookPage]
+    /// The package's `FileWrapper` from the last read or save.
+    /// Carry it so the writer can reuse its unchanged children.
+    var previousFileWrapper: FileWrapper?
+}
+
+struct NotebookMetadata: Codable {
+    var title: String
+    var pageOrder: [UUID]   // authoritative on-disk page list
+    var createdDate: Date
+}
+
+struct NotebookPage: Equatable {
+    var text: String
+    /// `true` when `text` is out of sync with the page on disk. Set when the
+    /// person edits a page; cleared in `snapshot(contentType:)` once the
+    /// snapshot capturing the edit has been handed to the writer.
+    var isChanged: Bool = false
+}
+
+@Observable
+final class NotebookDocument: ReadableDocument, WritableDocument {
+    static let readableContentTypes: [UTType] = [.notebook]
+
+    var metadata: NotebookMetadata
+    var pages: [UUID: NotebookPage]
+    var configuration: URLDocumentConfiguration
+    @ObservationIgnored 
+    private var previousFileWrapper: FileWrapper?
+
+    init(configuration: URLDocumentConfiguration) {
+        self.configuration = configuration
+        self.metadata = NotebookMetadata(title: "Untitled", pageOrder: [], createdDate: .now)
+        self.pages = [:]
+    }
+}
+
+extension NotebookDocument {
+    func reader(
+        configuration: sending DocumentReadConfiguration
+    ) -> sending FileWrapperDocumentReader<NotebookSnapshot> {
+        FileWrapperDocumentReader(configuration) { directory in
+            let childrenOnDisk = directory.fileWrappers ?? [:]
+            guard let metadataOnDisk =
+                childrenOnDisk["metadata.json"]?.regularFileContents else {
+                throw CocoaError(.fileReadCorruptFile)
+            }
+            let metadata = try JSONDecoder()
+                .decode(NotebookMetadata.self, from: metadataOnDisk)
+
+            // Load only the first page now. The rest stay on disk until
+            // the person opens them.
+            let pageWrappersOnDisk = childrenOnDisk["pages"]?.fileWrappers ?? [:]
+            var firstPage: [UUID: NotebookPage] = [:]
+            if let id = metadata.pageOrder.first,
+               let data = pageWrappersOnDisk["\(id.uuidString).txt"]?
+                   .regularFileContents,
+               let text = String(data: data, encoding: .utf8) {
+                firstPage[id] = NotebookPage(text: text)
+            }
+            return NotebookSnapshot(
+                metadata: metadata, pages: firstPage, fileWrapper: directory
+            )
+        }
+    }
+
+    @MainActor
+    func apply(
+        snapshot: sending NotebookSnapshot,
+        previous: sending NotebookSnapshot?
+    ) async throws {
+        self.metadata = snapshot.metadata
+        self.pages = snapshot.pages
+        self.previousFileWrapper = snapshot.previousFileWrapper
+    }
+
+    func writer(
+        configuration: sending DocumentWriteConfiguration
+    ) -> sending FileWrapperDocumentWriter<NotebookSnapshot> {
+        FileWrapperDocumentWriter(configuration) { snapshot in
+            let directory = snapshot.fileWrapper
+                ?? FileWrapper(directoryWithFileWrappers: [:])
+
+            // Replace metadata in place unconditionally since it is small.
+            if let existingMetadata = directory.fileWrappers?["metadata.json"] {
+                directory.removeFileWrapper(existingMetadata)
+            }
+            let metadataData = try JSONEncoder().encode(snapshot.metadata)
+            let metadataWrapper =
+                FileWrapper(regularFileWithContents: metadataData)
+            metadataWrapper.preferredFilename = "metadata.json"
+            directory.addFileWrapper(metadataWrapper)
+
+            // Reuse or create the "pages" subdirectory.
+            let pagesDirectoryWrapper = directory.fileWrappers?["pages"] ?? {
+                let created = FileWrapper(directoryWithFileWrappers: [:])
+                created.preferredFilename = "pages"
+                directory.addFileWrapper(created)
+                return created
+            }()
+
+            // Touch only the pages whose content changed since the last save.
+            // Unchanged pages are skipped entirely (no serialization, no
+            // wrapper replace), so `FileWrapper` doesn't re-write them to disk.
+            let existingPages = pagesDirectoryWrapper.fileWrappers ?? [:]
+            for (pageID, pageContent) in snapshot.pages where pageContent.isChanged {
+                let filename = "\(pageID.uuidString).txt"
+                if let existing = existingPages[filename] {
+                    pagesDirectoryWrapper.removeFileWrapper(existing)
+                }
+                let wrapper = FileWrapper(
+                    regularFileWithContents: Data(pageContent.text.utf8)
+                )
+                wrapper.preferredFilename = filename
+                pagesDirectoryWrapper.addFileWrapper(wrapper)
+            }
+
+            // Remove pages dropped from the document. `metadata.pageOrder` is
+            // authoritative, not the in-memory `pages`, which only holds
+            // pages the person opened.
+            let liveFilenames = Set(
+                snapshot.metadata.pageOrder.map { "\($0.uuidString).txt" }
+            )
+            for (filename, child) in existingPages where !liveFilenames.contains(filename) {
+                pagesDirectoryWrapper.removeFileWrapper(child)
+            }
+
+            return directory
+        }
+    }
+
+    @MainActor
+    func snapshot(contentType: UTType) async throws -> sending NotebookSnapshot {
+        let result = NotebookSnapshot(
+            metadata: metadata, pages: pages, fileWrapper: previousFileWrapper
+        )
+        // Clear the dirty flags on the document. The snapshot just captured
+        // owns those edits now; the writer will persist them, and any further
+        // edits start a fresh `isChanged` cycle.
+        for id in pages.keys {
+            pages[id]?.isChanged = false
+        }
+        return result
+    }
+}
+```
+
+> **Important:** `FileWrapper` loads file contents **on demand**. A child file may be gone or inaccessible by the time you call `regularFileContents`, even if it existed when you opened the package. Handle errors when reading children, not just when opening the wrapper.
+
+## Register undo actions (required for autosave)
+
+SwiftUI tracks unsaved changes **through undo actions**. Without registered undo actions, **SwiftUI won't autosave.** Read `\.undoManager` from the environment and route every mutation through a method that registers an undo action; calling the same method from the undo closure gives redo for free.
+
+```swift
+extension TextDocument {
+    func registerTextUndo(from previousText: String, undoManager: UndoManager?) {
+        undoManager?.registerUndo(withTarget: self) { document in
+            let current = document.text
+            document.text = previousText
+            document.registerTextUndo(from: current, undoManager: undoManager)
+        }
+        undoManager?.setActionName("Edit")
+    }
+}
+```
+
+## Custom readers and writers
+
+Use a custom `DocumentReader` / `DocumentWriter` only when the `FileWrapper` convenience types can't do what you need:
+
+- streaming reads or writes of a large media file in chunks,
+- direct URL access for AVFoundation, PDFKit, Core Image, or any C library that takes file paths,
+- a very large package where converting every child to `Data` to diff is too costly; a custom writer can compare snapshots directly via `previous`.
+
+`read` and `write` are **`nonisolated`** and run in the background; `read` returns a `sending` snapshot, `write` consumes one.
+
+```swift
+import CoreImage
+
+struct ImageSnapshot {
+    var image: CIImage?
+}
+
+@Observable
+final class ImageDocument: ReadableDocument, WritableDocument {
+    static let readableContentTypes: [UTType] = [.jpeg]
+
+    var displayImage: CGImage?
+    var configuration: URLDocumentConfiguration
+    private let context = CIContext()
+
+    init(configuration: URLDocumentConfiguration) {
+        self.configuration = configuration
+    }
+
+    struct Reader: DocumentReader {
+        nonisolated func read(
+            from source: URL, progress: consuming Subprogress
+        ) async throws -> sending ImageSnapshot {
+            guard let image = CIImage(contentsOf: source) else {
+                throw CocoaError(.fileReadCorruptFile)
+            }
+            return ImageSnapshot(image: image)
+        }
+    }
+
+    struct Writer: DocumentWriter {
+        let context: CIContext
+      
+        nonisolated func write(
+            content: sending ImageSnapshot, to destination: URL,
+            previous: sending ImageSnapshot?, progress: consuming Subprogress
+        ) async throws {
+            guard let outputImage = content.image else { return }
+            try context.writeJPEGRepresentation(
+                of: outputImage, to: destination,
+                colorSpace: outputImage.colorSpace ?? CGColorSpaceCreateDeviceRGB()
+            )
+        }
+    }
+
+    func reader(
+        configuration: sending DocumentReadConfiguration
+    ) -> sending Reader { Reader() }
+
+    func writer(
+        configuration: sending DocumentWriteConfiguration
+    ) -> sending Writer { Writer(context: context) }
+
+    @MainActor
+    func apply(snapshot: sending ImageSnapshot, previous: sending ImageSnapshot?) async throws {
+        guard let ciImage = snapshot.image else { return }
+        self.displayImage = context.createCGImage(ciImage, from: ciImage.extent)
+    }
+
+    @MainActor
+    func snapshot(contentType: UTType) async throws -> sending ImageSnapshot {
+        ImageSnapshot(image: displayImage.map { CIImage(cgImage: $0) })
+    }
+}
+```
+
+The `previous` parameter on the **custom** `write(…)` and `apply(…)` is the last successfully written / read snapshot. For packages, compare it to the new snapshot to skip unchanged files.
+
+## Report progress with `Subprogress`
+
+`read` and `write` receive `consuming Subprogress`. Call `start(totalCount:)` **once** to consume it and get a `ProgressManager`; call `complete(count:)` as units finish. `Subprogress` is `~Copyable`, so the compiler enforces single use; if never consumed, the assigned units auto-complete.
+
+Pick a coarse `totalCount` (chunks or files) to drive `fractionCompleted`. For display, set `totalByteCount` / `completedByteCount` (`UInt64`) or `totalFileCount` / `completedFileCount` (`Int`) on the `ProgressManager`. Don't drive `complete(count:)` byte-by-byte.
+
+```swift
+struct MediaSnapshot { var payload: Data }
+
+extension MediaDocument {
+    struct Writer: DocumentWriter {
+        nonisolated func write(
+            content: sending MediaSnapshot, to destination: URL,
+            previous: sending MediaSnapshot?, progress: consuming Subprogress
+        ) async throws {
+            let payload = content.payload
+            let totalBytes = payload.count
+            let chunkSize = 1 << 20                              // 1 MB
+            let chunkCount = (totalBytes + chunkSize - 1) / chunkSize
+
+            let progressManager = progress.start(totalCount: chunkCount)
+            progressManager.totalByteCount = UInt64(totalBytes)
+
+            try Data().write(to: destination)
+            let fileHandle = try FileHandle(forWritingTo: destination)
+            defer { try? fileHandle.close() }
+
+            var offset = 0
+            while offset < totalBytes {
+                let end = min(offset + chunkSize, totalBytes)
+                try fileHandle.write(contentsOf: payload[offset..<end])
+                progressManager.completedByteCount += UInt64(end - offset)
+                progressManager.complete(count: 1)
+                offset = end
+            }
+        }
+    }
+}
+```
+
+> **Note:** The `FileWrapperDocumentReader` / `FileWrapperDocumentWriter` closures don't take a `Subprogress`; only **custom** readers/writers report progress. This is `ProgressManager`, not the old `Progress`. Training data may reach for `Progress(totalUnitCount:)` or a `reporter(totalCount:)` factory; neither is correct here.
+
+## Coordinated disk access outside read/write
+
+SwiftUI coordinates file access for `read` and `write` automatically. To touch the file URL at any other time (e.g. reading one sub-file of a package on a tap), gate the access with the configuration's file coordinator so other processes coordinating on the same URL can synchronize. `URLDocumentConfiguration.fileURL` is readable from any thread (it's `nonisolated(unsafe)`); the coordinator provides the read/write synchronization.
+
+```swift
+let coordinator = document.configuration.makeFileCoordinator()
+var error: NSError?
+coordinator.coordinate(
+    readingItemAt: packageURL.appending(path: "metadata.json"),
+    options: [], error: &error
+) { url in
+    // read/decode here; handle errors
+}
+```
+
+`makeFileCoordinator()` is a lightweight factory; call it for **each** read/write to get a fresh `NSFileCoordinator`.
+
+## iOS launch scene and multiple creation sources
+
+```swift
+@main
+struct NotesApp: App {
+    var body: some Scene {
+        DocumentGroupLaunchScene("My Notes and Lists") {
+            NewDocumentButton("New Note", source: .note)
+            NewDocumentButton("New List", source: .list)
+        } background: {
+            LinearGradient(
+                colors: [.brandStart, .brandEnd],
+                startPoint: .top, endPoint: .bottom
+            )
+        }
+
+        DocumentGroup { document in
+            TextEditorView(document: document)
+        } makeDocument: { configuration, context in
+            TextDocument(configuration: configuration, context: context)
+        }
+    }
+}
+
+extension DocumentCreationSource {
+    static let note = DocumentCreationSource(id: "note")
+    static let list = DocumentCreationSource(id: "list")
+}
+```
+
+Read `context.creationSource` in your initializer to set the document up accordingly.
+
+## Export to a new location or format
+
+Use `fileExporter` with a `WritableDocument`:
+
+```swift
+.fileExporter(
+    isPresented: $isExporting, document: document,
+    contentType: .utf8PlainText, defaultFilename: "Text"
+) { result in
+    switch result {
+    case .success(let url): print("Exported to \(url)")
+    case .failure(let error): print("Export failed: \(error)")
+    }
+}
+```
+
+## Concurrency contract (common agent pitfalls)
+
+- **`reader(configuration:)` / `writer(configuration:)`** are synchronous factories. They return `sending` reader/writer values and run on the caller.
+- **`read(from:progress:)` / `write(content:to:previous:progress:)`** are `nonisolated` and run **in the background**. Mark them `nonisolated` exactly as shown. Do all heavy I/O and serialization here.
+- **`snapshot(contentType:)` / `apply(snapshot:previous:)`** are **`@MainActor`** and `async`. Keep them cheap.
+- **`URLDocumentConfiguration` is `@MainActor @Observable` but `Sendable`,** with `fileURL` / `lastContentModificationDate` exposed as `nonisolated(unsafe)`. Inside `read` / `write`, prefer the `source: URL` / `destination: URL` parameter the framework hands you; that's the URL for *this* operation, while `configuration.fileURL` reflects current state and may have moved (Save As, rename) by the time you read it.
+- Snapshots cross actor boundaries, hence the `sending` annotations. Either make the snapshot `Sendable`, or construct it fresh inside `snapshot(contentType:)` and don't retain it elsewhere.
+- Keep snapshot types, reader types, and writer types at **internal** access (the default). Protocol-required methods expose these types in their signatures, so marking them `private` or `fileprivate` causes "must be declared fileprivate because its type uses a private type" compile errors.
+- The `makeDocument` / `makeReadableDocument` closures are `async` and run on the main actor; `await` inside them to do off-main setup.
+
+## Quick API reference
+
+| Symbol | Role |
+| --- | --- |
+| `ReadableDocument` | Read-only document. `AnyObject`. Requires `readableContentTypes`, `reader(configuration:)`, `apply(snapshot:previous:)`. |
+| `WritableDocument` | Adds saving (independent of `ReadableDocument`). Requires `writableContentTypes`, `writer(configuration:)`, `snapshot(contentType:)`. `AnyObject`. `DocumentGroup`'s read-write init requires `Document: ReadableDocument & WritableDocument`. |
+| `DocumentReader` | `nonisolated func read(from:progress:) async throws -> sending Snapshot`. |
+| `DocumentWriter` | `nonisolated func write(content:to:previous:progress:) async throws`. |
+| `FileWrapperDocumentReader<Snapshot>` | Convenience reader (recommended); closure `(FileWrapper) async throws -> sending Snapshot`. |
+| `FileWrapperDocumentWriter<Snapshot>` | Convenience writer (recommended); **single-argument** closure `(Snapshot) async throws -> FileWrapper`. No `previous` parameter; retain the prior `FileWrapper` yourself for incremental package writes. |
+| `URLDocumentConfiguration` | `@MainActor @Observable`, `Sendable`. `fileURL: URL?` / `lastContentModificationDate: Date?` (both `nonisolated(unsafe)`); `makeFileCoordinator() -> NSFileCoordinator`; `creationSource: DocumentCreationSource?` (iOS/visionOS only). |
+| `DocumentReadConfiguration` / `DocumentWriteConfiguration` | Value configs exposing `contentType: UTType`. |
+| `DocumentCreationContext` | `creationSource: DocumentCreationSource?`: which `NewDocumentButton` created the document. |
+| `Subprogress` (Foundation) | `~Copyable` progress currency for custom `read`/`write`. Consume once: `start(totalCount:) -> ProgressManager`. |
+| `ProgressManager` (Foundation) | `complete(count:)` drives `fractionCompleted`. Auxiliary `totalByteCount`/`completedByteCount` (`UInt64`), `totalFileCount`/`completedFileCount` (`Int`). |
+| `DocumentGroup` | Scene. `init(editor:makeDocument:)` (read-write) / `init(viewer:makeReadableDocument:)` (read-only). |
+| `DocumentGroupLaunchScene` | iOS branded launch scene hosting `NewDocumentButton`s. |
+| `View.fileExporter(isPresented:document:contentType:defaultFilename:onCompletion:)` | Export a `WritableDocument`. |

--- a/skills/swiftui27/references/document-based-apps.md
+++ b/skills/swiftui27/references/document-based-apps.md
@@ -210,7 +210,7 @@ extension NotebookDocument {
                 firstPage[id] = NotebookPage(text: text)
             }
             return NotebookSnapshot(
-                metadata: metadata, pages: firstPage, fileWrapper: directory
+                metadata: metadata, pages: firstPage, previousFileWrapper: directory
             )
         }
     }
@@ -283,7 +283,7 @@ extension NotebookDocument {
     @MainActor
     func snapshot(contentType: UTType) async throws -> sending NotebookSnapshot {
         let result = NotebookSnapshot(
-            metadata: metadata, pages: pages, fileWrapper: previousFileWrapper
+            metadata: metadata, pages: pages, previousFileWrapper: previousFileWrapper
         )
         // Clear the dirty flags on the document. The snapshot just captured
         // owns those edits now; the writer will persist them, and any further

--- a/skills/swiftui27/references/item-binding.md
+++ b/skills/swiftui27/references/item-binding.md
@@ -1,0 +1,99 @@
+# Confirmation Dialog and Alert Item Binding
+**SDK Version:** 27.0 and later
+
+If the user's deployment target is below iOS 27 / macOS 27 / watchOS 27 / tvOS 27 / visionOS 27, the new APIs in this reference (`confirmationDialog(_:item:…)` and `alert(_:item:…)` overloads) require availability gating. See "Deployment target below SDK 27" below for the gating shape to use.
+
+`confirmationDialog` and `alert` gain overloads that take an `item: Binding<T?>` in place of an `isPresented: Binding<Bool>`. The dialog or alert presents while the binding holds a value, the unwrapped value is passed to the `actions` (and optional `message`) closures, and SwiftUI resets the binding to `nil` when it is dismissed. This is the presentation shape of `sheet(item:)` applied to dialogs and alerts; the earlier forms drove presentation from a separate `Bool` and read the data from a stored optional or a `presenting:` argument. `T` has no `Identifiable` requirement. When a dialog or alert acts on a specific value, such as the row a person tapped or the item pending deletion, prefer this `item:` overload over a separate `isPresented` Bool, a `presenting:` argument, or the older `Alert`-returning `alert(item:)`: one optional drives presentation and hands the value to the `actions`/`message` builders.
+
+## Confirmation dialog from an item binding
+
+`confirmationDialog(_:item:titleVisibility:actions:)` presents while `item` is non-nil and passes the unwrapped value to `actions`; the overload with a trailing `message:` closure receives the value as well. The title is a `LocalizedStringKey`, `Text`, or `StringProtocol`, and `titleVisibility` defaults to `.automatic`.
+
+```swift
+struct PhotoGrid: View {
+    @State private var photoToDelete: Photo?
+
+    var body: some View {
+        PhotoList(deleteAction: { photoToDelete = $0 })
+            .confirmationDialog("Delete photo?", item: $photoToDelete) { photo in
+                Button("Delete \(photo.name)", role: .destructive) {
+                    delete(photo)
+                }
+            } message: { photo in
+                Text("\(photo.name) will be removed from all of your devices.")
+            }
+    }
+}
+```
+
+**Availability:** iOS 27, macOS 27, watchOS 27, tvOS 27, visionOS 27.
+
+## Alert from an item binding
+
+`alert(_:item:actions:)` presents while `item` is non-nil and passes the unwrapped value to `actions`; the overload with a trailing `message:` closure receives the value as well. Like `confirmationDialog(_:item:)`, it takes a title plus `actions` (and optional `message`) builders. For a per-item alert, this is the form to use; do not synthesize a `Binding<Bool>` and pair it with `presenting:`, and do not reach for the `Alert`-returning `alert(item:) { _ in Alert(...) }` overload.
+
+```swift
+struct FolderView: View {
+    @State private var pendingRename: Folder?
+
+    var body: some View {
+        FolderList(renameAction: { pendingRename = $0 })
+            .alert("Rename folder", item: $pendingRename) { folder in
+                Button("Rename") { rename(folder) }
+                Button("Cancel", role: .cancel) {}
+            } message: { folder in
+                Text("Choose a new name for \(folder.name).")
+            }
+    }
+}
+```
+
+**Availability:** iOS 27, macOS 27, watchOS 27, tvOS 27, visionOS 27.
+
+## Deployment target below SDK 27
+
+When the user's deployment target is below SDK 27 and the answer needs a per-item dialog or alert, gate the new `item:` overload behind `#available` and provide a fallback for older OS versions using the existing `isPresented:` (and `presenting:` where the unwrapped value is needed). The shape:
+
+```swift
+@State private var photoToDelete: Photo?
+@State private var isConfirmingDelete = false
+
+var body: some View {
+    SomeContent()
+        .modifier(DeleteConfirmation(item: $photoToDelete, isPresented: $isConfirmingDelete))
+}
+
+private struct DeleteConfirmation: ViewModifier {
+    @Binding var item: Photo?
+    @Binding var isPresented: Bool
+
+    func body(content: Content) -> some View {
+        if #available(iOS 27, *) {
+            content.confirmationDialog("Delete photo?", item: $item) { photo in
+                Button("Delete \(photo.name)", role: .destructive) { /* delete */ }
+            } message: { photo in
+                Text("\(photo.name) will be removed.")
+            }
+        } else {
+            content.confirmationDialog(
+                "Delete photo?",
+                isPresented: $isPresented,
+                presenting: item
+            ) { photo in
+                Button("Delete \(photo.name)", role: .destructive) { /* delete */ }
+            } message: { photo in
+                Text("\(photo.name) will be removed.")
+            }
+        }
+    }
+}
+```
+
+Use this shape (or `@available(iOS 27, *)` on an enclosing declaration) whenever the prompt names a deployment target below SDK 27. Don't emit unconditional calls to the new `item:` overloads; the typecheck will fail with `'<API>' is only available in iOS 27.0 or newer`.
+
+## Availability summary
+
+| API | iOS | macOS | watchOS | tvOS | visionOS |
+|---|---|---|---|---|---|
+| `confirmationDialog(_:item:titleVisibility:actions:)` / `…actions:message:)` | 27 | 27 | 27 | 27 | 27 |
+| `alert(_:item:actions:)` / `…actions:message:)` | 27 | 27 | 27 | 27 | 27 |

--- a/skills/swiftui27/references/item-binding.md
+++ b/skills/swiftui27/references/item-binding.md
@@ -56,16 +56,14 @@ When the user's deployment target is below SDK 27 and the answer needs a per-ite
 
 ```swift
 @State private var photoToDelete: Photo?
-@State private var isConfirmingDelete = false
 
 var body: some View {
     SomeContent()
-        .modifier(DeleteConfirmation(item: $photoToDelete, isPresented: $isConfirmingDelete))
+        .modifier(DeleteConfirmation(item: $photoToDelete))
 }
 
 private struct DeleteConfirmation: ViewModifier {
     @Binding var item: Photo?
-    @Binding var isPresented: Bool
 
     func body(content: Content) -> some View {
         if #available(iOS 27, *) {
@@ -77,7 +75,10 @@ private struct DeleteConfirmation: ViewModifier {
         } else {
             content.confirmationDialog(
                 "Delete photo?",
-                isPresented: $isPresented,
+                isPresented: Binding(
+                    get: { item != nil },
+                    set: { if !$0 { item = nil } }
+                ),
                 presenting: item
             ) { photo in
                 Button("Delete \(photo.name)", role: .destructive) { /* delete */ }

--- a/skills/swiftui27/references/reorderable.md
+++ b/skills/swiftui27/references/reorderable.md
@@ -1,0 +1,189 @@
+# Reorderable Containers
+**SDK Version:** 27.0 and later
+
+SwiftUI now supports drag-to-reorder in *any* container (`List`, `LazyVStack`, `LazyVGrid`, stacks, or a custom layout), not just `List`. Previously, drag-to-reorder was effectively `List`-only (via `onMove(perform:)`) or hand-rolled with a drag gesture. Two modifiers work together: `.reorderable()` goes on the `ForEach` (it is declared on `DynamicViewContent`), and `.reorderContainer(for:…)` goes on the enclosing container. When a drag ends, SwiftUI calls your `move` closure with a `ReorderDifference` describing the change, which you apply to your own data.
+
+**Availability:** iOS 27, macOS 27, watchOS 27, visionOS 27. **tvOS: unavailable.**
+
+If the user's deployment target is below iOS 27 / macOS 27 / watchOS 27 / visionOS 27, do not use these APIs unconditionally.
+
+## Basic usage
+
+```swift
+struct StickerGrid: View {
+    @State private var stickers: [Sticker] = []
+
+    var body: some View {
+        ScrollView {
+            LazyVGrid(columns: columns) {
+                ForEach(stickers) { sticker in
+                    StickerView(sticker)
+                }
+                .reorderable()
+            }
+            .reorderContainer(for: Sticker.self) { difference in
+                // Update `stickers` to reflect the move (see "Applying the difference").
+            }
+        }
+    }
+}
+```
+
+`Sticker` must be `Identifiable` for the `for:` overload (it keys on `\.id`). If your type is not `Identifiable`, or you want a different identifier, use the `itemID:` keypath overload: `reorderContainer(for: Sticker.self, itemID: \.code)` paired with the same `.reorderable()`.
+
+## Applying the difference
+
+Your `move` closure receives a `ReorderDifference<ItemID, CollectionID>`:
+
+```swift
+public struct ReorderDifference<ItemID, CollectionID> {
+    public var sources: [ItemID]            // the items being moved
+    public var destination: Destination
+
+    public struct Destination {
+        @frozen public enum Position {
+            case before(ItemID)             // insert the sources before this item
+            case end                        // append the sources to the end
+        }
+        public var position: Position
+        public var collectionID: CollectionID
+    }
+}
+```
+
+`sources` is the items being moved; `destination.position` is where they go (`.before(id)` places them ahead of that item, `.end` appends). Apply this to your data however fits your model. As one example, using a `Set` for O(1) membership and a single in-place pass, factored into a reusable extension on `ReorderDifference`:
+
+```swift
+extension ReorderDifference where CollectionID == ReorderableSingleCollectionIdentifier {
+    func apply<C>(to collection: inout C)
+        where C: RangeReplaceableCollection,
+              C.Element: Identifiable,
+              C.Element.ID == ItemID
+    {
+        let moving = Set(sources)
+        guard !moving.isEmpty else { return }
+
+        // One in-place pass: drop the moved items and capture them in order.
+        var moved: [C.Element] = []
+        moved.reserveCapacity(moving.count)
+        collection.removeAll { element in
+            guard moving.contains(element.id) else { return false }
+            moved.append(element)
+            return true
+        }
+
+        switch destination.position {
+        case .before(let id):
+            let index = collection.firstIndex { $0.id == id } ?? collection.endIndex
+            collection.insert(contentsOf: moved, at: index)
+        case .end:
+            collection.append(contentsOf: moved)
+        }
+    }
+}
+```
+
+(That example's `CollectionID == ReorderableSingleCollectionIdentifier` constraint scopes it to single-collection containers; sectioned containers route by `destination.collectionID` instead. See below.)
+
+## Sections and multiple collections
+
+When a container has more than one collection (for example, `List` sections), tag each `ForEach` with `.reorderable(collectionID:)` and declare the collection identifier type on the container with `reorderContainer(for:in:)`:
+
+```swift
+struct Category: Identifiable {
+    let id = UUID()
+    var name: String
+    var items: [Item]
+}
+
+// In your view's body:
+List {
+    ForEach(categories) { category in
+        Section(category.name) {
+            ForEach(category.items) { item in
+                ItemView(item)
+            }
+            .reorderable(collectionID: category.id)
+        }
+    }
+}
+.reorderContainer(for: Item.self, in: Category.ID.self) { difference in
+    // Apply the move. difference.destination.collectionID identifies the
+    // destination section; remove the items from their old section and insert
+    // them at difference.destination.position.
+}
+```
+
+The type you pass to `in:` is your section model's `ID` (here `Category.ID`), not SwiftUI's `Section`. For a single-collection container, the `CollectionID` is `ReorderableSingleCollectionIdentifier` (an opaque empty identifier SwiftUI supplies for you).
+
+## Drag-and-drop integration
+
+`.reorderContainer(for:)` already acts as a drag container and a drop destination, so dragging to reorder works on its own. To customize it, declare your own `dragContainer(for:)` (to control selection, the dragged item representation, or to let items drag out to other views and apps) or `dropDestination(for:)` (to accept dropped items at the reorder position) on the same container. A standalone `.draggable` does not customize the reorder container; provide a `dragContainer` instead.
+
+> **Availability:** these drag-and-drop modifiers are iOS 27 / visionOS 27, and macOS 26 to 27. `dragContainer` / `draggable(containerItemID:)` / `dropDestination` are macOS 26, but `DropSession.reorderDestination(for:)` requires macOS 27 (see the table below). tvOS and **watchOS are unavailable**, so a reorderable list works on watchOS (reordering is local to the container), but this drag-and-drop integration, which relies on system-wide drag and drop, does not.
+
+**Customize the drag.** Declare your own `dragContainer(for:)` on the container to build the drag payload from an item identifier. `.reorderable()` already marks each child as draggable through the container, so the children themselves stay bare:
+
+```swift
+LazyVGrid(columns: columns) {
+    ForEach(stickers) { sticker in
+        StickerView(sticker)
+    }
+    .reorderable()
+}
+.reorderContainer(for: Sticker.self) { difference in /* apply the move to stickers */ }
+.dragContainer(for: Sticker.self) { draggedID in
+    stickers.first { $0.id == draggedID }.map { [$0] } ?? []
+}
+```
+
+Return an empty collection from the `dragContainer` closure to disable the drag for a given item.
+
+**Combining items: drop one onto another.** Put `.dropDestination(for:isEnabled:)` on each child. SwiftUI invokes the closure only when `isEnabled` is true, so a per-item predicate (`canCombine`, a state check, etc.) goes in `isEnabled:`, not inside the closure. The closure's signature is `(items: [T], session: DropSession) -> Void`. SwiftUI handles drop visualization itself: while a drag hovers an `isEnabled` child, the system signals that item as the drop target, and when the drag moves between children the system shows a reorder gap. You do not need to add hover state to your view. Do not use the `dropDestination(for:) { } isTargeted: { }` overload here; that overload reports hover state for custom visual feedback, it does not gate combining, and it is the wrong choice for drop-to-combine.
+
+```swift
+LazyVGrid(columns: columns) {
+    ForEach(stickers) { sticker in
+        StickerView(sticker)
+            .dropDestination(for: Sticker.self, isEnabled: sticker.allowsCombining) { items, _ in
+                // Void-returning: no `return true` / `return false` in this closure.
+                guard let i = stickers.firstIndex(where: { $0.id == sticker.id }) else { return }
+                let droppedIDs = Set(items.map(\.id))
+                stickers[i].name = ([stickers[i].name] + items.map(\.name)).joined(separator: "+")
+                stickers.removeAll { droppedIDs.contains($0.id) }
+            }
+    }
+    .reorderable()
+}
+.reorderContainer(for: Sticker.self) { difference in difference.apply(to: &stickers) }
+.dragContainer(for: Sticker.self) { draggedID in
+    stickers.first { $0.id == draggedID }.map { [$0] } ?? []
+}
+```
+
+**Accepting drops at the reorder position.** Put `.dropDestination(for:)` on the container and ask the session where the drop landed via `reorderDestination(for:)`, which returns a `ReorderDifference.Destination?` (`nil` means the person dropped without hovering a specific item; append to the end in that case). This overload is for placement, not combining; for combine, use the per-child form above.
+
+```swift
+.dropDestination(for: Sticker.self) { items, session in
+    guard let destination = session.reorderDestination(for: Sticker.self) else {
+        stickers.append(contentsOf: items)
+        return
+    }
+    switch destination.position {
+    case .before(let id):
+        let index = stickers.firstIndex { $0.id == id } ?? stickers.endIndex
+        stickers.insert(contentsOf: items, at: index)
+    case .end:
+        stickers.append(contentsOf: items)
+    }
+}
+```
+
+## Availability summary
+
+| API | iOS | macOS | watchOS | tvOS | visionOS |
+|---|---|---|---|---|---|
+| `reorderable()` / `reorderContainer(for:…)` | 27 | 27 | 27 | n/a | 27 |
+| `dragContainer` / `draggable(containerItemID:)` | 27 | 26 | n/a | n/a | 27 |
+| `DropSession` / `dropDestination(for:…session…)` | 26 | 26 | n/a | n/a | 26 |
+| `DropSession.reorderDestination(for:)` | 27 | 27 | n/a | n/a | 27 |

--- a/skills/swiftui27/references/state-macro.md
+++ b/skills/swiftui27/references/state-macro.md
@@ -1,0 +1,87 @@
+# @State as Macro
+**SDK Version:** 27.0 and later
+
+`@State` has been migrated from a property wrapper to a macro. As a result, you may encounter source incompatibility issues in existing or new code. Here are the issues and how to fix them:
+
+## Init Assignment Errors
+**Issue:**
+Projects that provide an initial value for a `@State` variable decleration and try to assign its value again in a initializer, before all stored properties are assigned, will encounter errors like:
+
+```
+error: Variable 'self.name' used before being initialized
+```
+
+For example, this code will fail to compile:
+```swift
+import SwiftUI
+
+struct ContentView: View {
+    var name: String
+    @State private var counter: Int = 0
+
+    init(name: String) {
+        self.counter = 42
+        self.name = name
+    }
+
+    var body: some View { Text("\(name): \(counter)") }
+}
+```
+
+**Fix:**
+ Drop the initial value expression at `@State` decleration, only assign it in the init. This ensures the value is correctly initialized.
+
+**Reason:**
+The `@State` macro synthesizes real backing storage properties. If your `init` assigns to `@State` properties before other stored properties are set, the compiler catches this as premature `self` usage.
+
+**Warning:**
+Assigning a new value to a `@State` property that has an initial value is an anti-pattern and won't produce the expected behavior.
+
+For example, the `body` for the following code will see `0` as the value for `counter`
+```swift
+struct ContentView: View {
+    @State private var counter: Int = 0
+
+    init() {
+        self.counter = 42
+    }
+}
+```
+
+## Redeclaration errors with composed property wrappers
+**Issue:**
+Projects that apply additional property wrappers to properties using `@State` might see errors like:
+
+```
+error: invalid redeclaration of synthesized property '_counter'
+```
+
+**Fix:**
+Refactor the property wrapper composition: remove the redundant wrapper or restructure so backing storage names don't collide. If unsure, ask the user how they prefer to proceed.
+
+**Reason:**
+Both the composed property wrapper and the `@State` macro try to synthesize a backing storage property with the same name.
+
+## Private memberwise init not synthesized
+**Issue:**
+Normally, if a type has only private members, and no explicit initializer, Swift synthesizes a private memberwise `init` that's only accessible in inits defined in extensions of the type. For views with `@State`, this synthesis doesn't occur. This causes an error at the call site when attempting to use the missing `init`:
+
+```
+struct Foo: View {
+  // all members that would be in the synthesized init are private
+  @State private var bar = 0
+  private let baz: Int
+}
+
+extension Foo {
+  init(_ bar: Int, baz: Int) {
+    self.init(bar: bar, baz) // error
+  }
+}
+```
+
+**Fix:**
+Explicitly define the memberwise initializer instead of relying on the compiler-synthesized one.
+
+**Reason:**
+The `@State` macro generates two `init` accessors targeting the same backing property (`__y`) – one on the original property and one on the synthesized `_y` peer – which, per SE-0400, makes the compiler skip memberwise `init` synthesis when multiple `init` accessors target the same stored property.

--- a/skills/swiftui27/references/swipe-actions.md
+++ b/skills/swiftui27/references/swipe-actions.md
@@ -1,0 +1,65 @@
+# Swipe Actions
+**SDK Version:** 27.0 and later
+
+The `swipeActions(edge:allowsFullSwipe:content:)` row modifier previously took effect only inside a `List`. The 2027 SDKs let it work in any scrollable container (a `ScrollView` containing a `LazyVStack`, `LazyVGrid`, or a stack) once that container is marked with the new `swipeActionsContainer()` modifier, which coordinates the swipe across the items in the container. A new overload of the row modifier adds an `onPresentationChanged` callback that reports when a row's actions are revealed or hidden.
+
+If the user's deployment target is below iOS 27 / macOS 27 / watchOS 27 / visionOS 27, the new `swipeActionsContainer()` modifier and the `swipeActions(…onPresentationChanged:)` overload require availability gating. The original `swipeActions(edge:allowsFullSwipe:content:)` row modifier on a `List` row has been available since iOS 15 / macOS 12 / watchOS 8 / visionOS 1 and does not need gating.
+
+## Swipe actions in a scrollable container
+
+Put `swipeActionsContainer()` on the scrollable container and keep the existing `swipeActions(edge:allowsFullSwipe:content:)` on each row inside it. The row modifier is unchanged: `edge` defaults to `.trailing` (pass `.leading` for the leading edge), `allowsFullSwipe` defaults to `true`, and the content builder holds the buttons.
+
+```swift
+struct StickerListView: View {
+    @State private var stickers: [Sticker] = []
+
+    var body: some View {
+        ScrollView {
+            LazyVStack {
+                ForEach(stickers) { sticker in
+                    StickerRow(sticker)
+                        .swipeActions {
+                            Button(role: .destructive) {
+                                stickers.removeAll { $0.id == sticker.id }
+                            } label: {
+                                Label("Delete", systemImage: "trash")
+                            }
+                        }
+                }
+            }
+        }
+        .swipeActionsContainer()
+    }
+}
+```
+
+Without `swipeActionsContainer()` on the container, `swipeActions` on a row outside a `List` has no effect. The modifier also applies to a `LazyVGrid` or a plain stack inside the `ScrollView`.
+
+**Availability:** `swipeActionsContainer()` is iOS 27, macOS 27, watchOS 27, visionOS 27; tvOS unavailable. The `swipeActions(edge:allowsFullSwipe:content:)` row modifier is iOS 15, macOS 12, watchOS 8, visionOS 1; tvOS unavailable.
+
+## Reacting when actions are shown or hidden
+
+The `swipeActions(edge:allowsFullSwipe:content:onPresentationChanged:)` overload adds an `onPresentationChanged` closure that receives `true` when the row's actions become visible and `false` when they hide.
+
+```swift
+StickerRow(sticker)
+    .swipeActions {
+        Button(role: .destructive) {
+            stickers.removeAll { $0.id == sticker.id }
+        } label: {
+            Label("Delete", systemImage: "trash")
+        }
+    } onPresentationChanged: { isPresented in
+        revealedSticker = isPresented ? sticker.id : nil
+    }
+```
+
+**Availability:** iOS 27, macOS 27, watchOS 27, visionOS 27; tvOS unavailable.
+
+## Availability summary
+
+| API | iOS | macOS | watchOS | tvOS | visionOS |
+|---|---|---|---|---|---|
+| `swipeActions(edge:allowsFullSwipe:content:)` (row modifier) | 15 | 12 | 8 | n/a | 1 |
+| `swipeActionsContainer()` | 27 | 27 | 27 | n/a | 27 |
+| `swipeActions(…onPresentationChanged:)` | 27 | 27 | 27 | n/a | 27 |

--- a/skills/swiftui27/references/toolbar.md
+++ b/skills/swiftui27/references/toolbar.md
@@ -1,0 +1,145 @@
+# Toolbar
+**SDK Version:** 27.0 and later
+
+If the user's deployment target is below iOS 27 / macOS 27 / watchOS 27 / visionOS 27, the new APIs in this reference (`visibilityPriority(_:)`, `ToolbarOverflowMenu` and its `toolbarOverflowMenu` modifier, `.topBarPinnedTrailing`, `toolbarMinimizeBehavior(_:for:)`, `toolbarMinimizationSafeAreaAdjustment(_:for:)`, `contentMarginsRemoved(_:)`, `ToolbarPlacement.statusBar`, and `EmptyView` as toolbar content) require availability gating. The `ForEach` toolbar conformance back-deploys to iOS 16 / macOS 13 / watchOS 9 / tvOS 16 / visionOS 1 when built with the 2027 SDK and does not need gating. See "Deployment target below SDK 27" below for the gating shape to use.
+
+When a toolbar has more items than fit the available width (a narrow window, a resized app, or iPhone), the system moves the overflow into a trailing overflow menu. The 2027 SDKs add modifiers to control what stays in the bar, what overflows, and what is pinned, to minimize a bar as the person scrolls, and to adjust toolbar content margins and status-bar visibility. `ForEach` and `EmptyView` also work inside a `toolbar` builder now.
+
+## Visibility priority
+
+`visibilityPriority(_:)` sets how readily a piece of `ToolbarContent` (a `ToolbarItem` or `ToolbarItemGroup`) overflows when space is tight: higher-priority content stays in the bar, lower-priority content moves to the overflow menu first. The priorities are `.automatic` (the default), `.low`, and `.high`, or you can derive one relative to another with `ToolbarItemVisibilityPriority(higherThan:)` or `(lowerThan:)`.
+
+```swift
+.toolbar {
+    ToolbarItemGroup {
+        UndoButton()
+        RedoButton()
+    }
+    .visibilityPriority(.high)
+}
+```
+
+**Availability:** iOS 27, macOS 26.1, watchOS 27, tvOS 27, visionOS 27. `.low` and `.high` are iOS and macOS only; the relative initializers are iOS 27 / macOS 27. On watchOS, tvOS, and visionOS only `.automatic` exists.
+
+## Overflow menu
+
+`ToolbarOverflowMenu` holds content that always lives in the overflow menu instead of the bar. Its body is a view builder, so the buttons go directly inside it. The `.toolbarOverflowMenu { }` modifier on `View` does the same outside a `toolbar` builder.
+
+```swift
+.toolbar {
+    ToolbarOverflowMenu {
+        ChoosePhotoButton()
+        ExportAsImageButton()
+        ClearAllStickersButton()
+    }
+}
+```
+
+**Availability:** iOS 27, visionOS 27.
+
+## Pinned trailing item
+
+A `ToolbarItem` placed with `.topBarPinnedTrailing` stays in the trailing position and never moves to the overflow menu, no matter how constrained the bar is.
+
+```swift
+.toolbar {
+    ToolbarItem(placement: .topBarPinnedTrailing) {
+        ShareButton()
+    }
+}
+```
+
+**Availability:** iOS 27, visionOS 27.
+
+## Minimize on scroll
+
+`toolbarMinimizeBehavior(_:for:)` minimizes a bar as the person scrolls. It takes one of `ToolbarMinimizeBehavior.automatic` (the system decides), `.onScrollDown`, `.onScrollUp`, or `.never`. The companion `toolbarMinimizationSafeAreaAdjustment(_:for:)` controls whether content's safe area shrinks to follow the bar as it minimizes, with `.automatic`, `.enabled`, or `.disabled`.
+
+```swift
+ScrollView {
+    StickerListView()
+}
+.toolbarMinimizeBehavior(.onScrollDown, for: .navigationBar)  // or .automatic, .onScrollUp, .never
+```
+
+**Availability:** iOS 27, macOS 27, watchOS 27, tvOS 27, visionOS 27. `.onScrollDown` / `.onScrollUp` / `.never` and `.enabled` / `.disabled` are iOS only; other platforms use `.automatic`.
+
+## Toolbar content margins
+
+`contentMarginsRemoved(_:)` removes the default margins around a piece of toolbar content, so it sits flush with the edge of the bar.
+
+```swift
+.toolbar {
+    ToolbarItem(placement: .topBarTrailing) {
+        AvatarView()
+    }
+    .contentMarginsRemoved()
+}
+```
+
+**Availability:** iOS 27, macOS 27, watchOS 27, tvOS 27, visionOS 27.
+
+## Status bar visibility
+
+The status bar is now a `ToolbarPlacement`, so you control its visibility with `toolbarVisibility(_:for:)`. On iOS this is the replacement for `statusBarHidden(_:)`.
+
+```swift
+.toolbarVisibility(.hidden, for: .statusBar)
+```
+
+**Availability:** iOS 27.
+
+## Dynamic content
+
+`ForEach` now conforms to `ToolbarContent`, so a `toolbar` builder can generate items from a collection just as a view body does. `EmptyView` conforms now as well, for an explicit empty branch. (Conditionals such as `if` and `#if`, and multiple items in one builder, already worked before 27.)
+
+```swift
+.toolbar {
+    ForEach(quickActions) { action in
+        ToolbarItem {
+            Button(action.title) { action.perform() }
+        }
+    }
+}
+```
+
+**Availability:** the `ForEach` conformance back-deploys (iOS 16, macOS 13, watchOS 9, tvOS 16, visionOS 1) when built with the 2027 SDK; the `EmptyView` conformance requires iOS 27, macOS 27, watchOS 27, tvOS 27, visionOS 27.
+
+## Deployment target below SDK 27
+
+When the user's deployment target is below SDK 27 and the answer needs any of the new APIs above, gate the whole `.toolbar { … }` body in a single `if #available` block and provide a fallback for older OS versions. Conditionals already worked in toolbar builders before SDK 27, so this is the cleanest place to put the gate:
+
+```swift
+.toolbar {
+    if #available(iOS 27, *) {
+        // New SDK 27 APIs go here, for example:
+        ToolbarItemGroup { /* … */ }
+            .visibilityPriority(.high)
+        ToolbarItem(placement: .topBarPinnedTrailing) { /* … */ }
+        ToolbarOverflowMenu { /* … */ }
+    } else {
+        // Older fallback: plain ToolbarItem entries (or whatever older toolbar shape works for the app).
+        ToolbarItem { /* … */ }
+    }
+}
+```
+
+Use this shape (or `@available(iOS 27, *)` on an enclosing declaration) whenever the prompt names a deployment target below SDK 27. Don't emit unconditional calls to the APIs above; the typecheck will fail with `'<API>' is only available in iOS 27.0 or newer`.
+
+## Availability summary
+
+| API | iOS | macOS | watchOS | tvOS | visionOS |
+|---|---|---|---|---|---|
+| `visibilityPriority(_:)`, `.automatic` | 27 | 26.1 | 27 | 27 | 27 |
+| `.low` / `.high` | 27 | 26.1 | n/a | n/a | n/a |
+| `init(lowerThan:)` / `init(higherThan:)` | 27 | 27 | n/a | n/a | n/a |
+| `ToolbarOverflowMenu` / `toolbarOverflowMenu` | 27 | n/a | n/a | n/a | 27 |
+| `.topBarPinnedTrailing` | 27 | n/a | n/a | n/a | 27 |
+| `toolbarMinimizeBehavior(_:for:)`, `.automatic` | 27 | 27 | 27 | 27 | 27 |
+| `.onScrollDown` / `.onScrollUp` / `.never` | 27 | n/a | n/a | n/a | n/a |
+| `toolbarMinimizationSafeAreaAdjustment(_:for:)`, `.automatic` | 27 | 27 | 27 | 27 | 27 |
+| `.enabled` / `.disabled` (safe-area adjustment) | 27 | n/a | n/a | n/a | n/a |
+| `contentMarginsRemoved(_:)` | 27 | 27 | 27 | 27 | 27 |
+| `ToolbarPlacement.statusBar` | 27 | n/a | n/a | n/a | n/a |
+| `ForEach` as toolbar content (back-deploys) | 16 | 13 | 9 | 16 | 1 |
+| `EmptyView` as toolbar content | 27 | 27 | 27 | 27 | 27 |


### PR DESCRIPTION
## What

Vendors Apple's nine authoritative reference files (exported from Xcode 27 via `xcrun agent skills export`, mirrored at wisdom-in-a-nutshell/agents) into `skills/swiftui27/references/`, and rewrites the skill's SKILL.md to route to them.

## Why enrich, not replace

Apple's `swiftui-whats-new-27` is authoritative for what it covers — including high-value content Cal's skill lacked: the **@State property-wrapper→macro source breaks** (with the trap that reordering init assignments compiles but misbehaves at runtime), @ContentBuilder ambiguities, AsyncImage caching, swipe actions outside List, and item-binding alerts. But it omits things Cal's skill verified against the SDK: navigation transitions (`AnyNavigationTransition`, `.crossFade`), copy/cut/paste modifiers, `onDragSessionUpdated`, tab bar minimize, and Liquid Glass background extension. Those stay as Cal sections, marked ✅.

## Structure

- `references/*.md` — Apple-authored, vendored verbatim, declared authoritative over inline notes on conflict.
- SKILL.md — routing index for Apple topics + Cal-only sections + OOD notes.
- Description frontmatter now quotes the exact SDK 27 compiler error strings (Apple's style) so the skill triggers on the error, not just the topic.

## Maintenance

Re-export and re-vendor when new Xcode 27 betas update the skill (noted in Sourcing section + cal.md decision entry).

🤖 Generated with [Claude Code](https://claude.com/claude-code)